### PR TITLE
Support event subscription for geth-rpcnode

### DIFF
--- a/rpcnode/github-ethereum-go-ethereum/config.go
+++ b/rpcnode/github-ethereum-go-ethereum/config.go
@@ -18,6 +18,7 @@ package github_ethereum_go_ethereum
 
 import (
 	"aurora-relayer-go-common/log"
+
 	gel "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/spf13/viper"
@@ -106,6 +107,7 @@ type Config struct {
 // HTTPModules: ["net", "web3", "eth"]
 // HTTPVirtualHosts: []
 // HTTPTimeouts: rpc.DefaultHTTPTimeouts
+// -> WS parameters are optional. Add the following WS parameters to make them mandatory.
 // WSHost: DefaultHost
 // WSPort: DefaultWSPort
 // WSModules: ["net", "web3", "eth"]
@@ -120,11 +122,6 @@ func defaultConfig() *Config {
 		HTTPVirtualHosts: []string{},
 		HTTPCors:         []string{},
 		HTTPTimeouts:     rpc.DefaultHTTPTimeouts,
-		WSPort:           DefaultWSPort,
-		WSPathPrefix:     DefaultPathPrefix,
-		WSHost:           DefaultHost,
-		WSModules:        []string{"net", "web3", "eth"},
-		WSOrigins:        []string{},
 		Logger:           NewGoEthLogger(log.Log()),
 	}
 }

--- a/rpcnode/github-ethereum-go-ethereum/events/broker.go
+++ b/rpcnode/github-ethereum-go-ethereum/events/broker.go
@@ -1,0 +1,215 @@
+package eventbroker
+
+import (
+	"aurora-relayer-go-common/log"
+	"aurora-relayer-go-common/utils"
+	"bytes"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type Type byte
+
+const (
+	// logsChSize is the size of channel listening to Logs event.
+	LogsChSize = 5
+	// newHeadsChSize is the size of channel listening to NewHeads event.
+	NewHeadsChSize = 5
+)
+
+const (
+	// UnknownSubscription indicates an unknown subscription type
+	UnknownSubscription Type = iota
+	// NewHeadsSubscription tracks the newly added block responses
+	NewHeadsSubscription
+	// LogsSubscription queries for new or removed (chain reorg) logs
+	LogsSubscription
+)
+
+type Subscription struct {
+	id         rpc.ID
+	typ        Type
+	created    time.Time
+	logOpts    utils.LogSubscriptionOptions
+	newHeadsCh chan *utils.BlockResponse
+	logsCh     chan []*utils.LogResponse
+}
+
+// EventBroker offers support to manage event subscriptions and broadcast the incoming events to
+// subscribed objects.
+type EventBroker struct {
+	l                 *log.Logger
+	stopCh            chan bool
+	publishNewHeadsCh chan *utils.BlockResponse
+	publishLogsCh     chan []*utils.LogResponse
+	subNewHeadsCh     chan *Subscription
+	subLogsCh         chan *Subscription
+	unsubNewHeadsCh   chan *Subscription
+	unsubLogsCh       chan *Subscription
+	DebugInfo         chan int
+}
+
+// Creates a new EventsForGoEth object
+func NewEventBroker() *EventBroker {
+	return &EventBroker{
+		l:                 log.Log(),
+		stopCh:            make(chan bool, 1),
+		publishNewHeadsCh: make(chan *utils.BlockResponse, NewHeadsChSize),
+		publishLogsCh:     make(chan []*utils.LogResponse, LogsChSize),
+		subNewHeadsCh:     make(chan *Subscription),
+		subLogsCh:         make(chan *Subscription),
+		unsubNewHeadsCh:   make(chan *Subscription),
+		unsubLogsCh:       make(chan *Subscription),
+		DebugInfo:         make(chan int),
+	}
+}
+
+// SubscribeNewHeads creates a new subscription and signals the
+// EventBroker subscription channel to handle the subscription map
+func (eb *EventBroker) SubscribeNewHeads(ch chan *utils.BlockResponse) *Subscription {
+	sub := &Subscription{
+		id:         rpc.NewID(),
+		typ:        NewHeadsSubscription,
+		created:    time.Now(),
+		newHeadsCh: ch,
+		logsCh:     make(chan []*utils.LogResponse),
+	}
+	eb.subNewHeadsCh <- sub
+	eb.l.Info().Msgf("new subscription request to New Heads with Id: [%s]", sub.id)
+	return sub
+}
+
+// SubscribeLogs creates a new subscription and signals the
+// EventBroker subscription channel to handle the subscription map
+func (eb *EventBroker) SubscribeLogs(opts utils.LogSubscriptionOptions, ch chan []*utils.LogResponse) *Subscription {
+	sub := &Subscription{
+		id:         rpc.NewID(),
+		typ:        LogsSubscription,
+		created:    time.Now(),
+		logOpts:    opts,
+		newHeadsCh: make(chan *utils.BlockResponse),
+		logsCh:     ch,
+	}
+	eb.subLogsCh <- sub
+	eb.l.Info().Msgf("new subscription request to Logs with Id: [%s]", sub.id)
+	return sub
+}
+
+// UnsubscribeFromNewHeads signals the EventBroker's related channel
+// to delete the subscription
+func (eb *EventBroker) UnsubscribeFromNewHeads(sub *Subscription) {
+	eb.unsubNewHeadsCh <- sub
+	eb.l.Info().Msgf("unsubscription request to New Heads with Id: [%s]", sub.id)
+}
+
+// UnsubscribeFromLogs signals the EventBroker's related channel
+// to delete the subscription
+func (eb *EventBroker) UnsubscribeFromLogs(sub *Subscription) {
+	eb.unsubLogsCh <- sub
+	eb.l.Info().Msgf("unsubscription request to Logs with Id: [%s]", sub.id)
+}
+
+// This is the main loop of the EventBroker that receives and distributes the events.
+func (eb *EventBroker) Start() {
+	subsNewHeads := map[rpc.ID]*Subscription{}
+	subsLogs := map[rpc.ID]*Subscription{}
+	for {
+		select {
+		case <-eb.stopCh:
+			return
+		// this case is only for testing purposes
+		case req := <-eb.DebugInfo:
+			switch req {
+			case -1:
+				eb.DebugInfo <- len(subsNewHeads)
+			case -2:
+				eb.DebugInfo <- len(subsLogs)
+			}
+		case sub := <-eb.subNewHeadsCh:
+			subsNewHeads[sub.id] = sub
+		case sub := <-eb.subLogsCh:
+			subsLogs[sub.id] = sub
+		case sub := <-eb.unsubNewHeadsCh:
+			delete(subsNewHeads, sub.id)
+		case sub := <-eb.unsubLogsCh:
+			delete(subsLogs, sub.id)
+		case msg := <-eb.publishNewHeadsCh:
+			for _, v := range subsNewHeads {
+				// v.newHeadsCh is buffered, use non-blocking send to protect the broker:
+				// timeout preferred instead of default to be able to tolerate slight delays
+				select {
+				case v.newHeadsCh <- msg:
+				case <-time.After(10 * time.Millisecond):
+					eb.l.Warn().Msg("Publishing to New Heads channel fall into DEFAULT!")
+				}
+			}
+		case logs := <-eb.publishLogsCh:
+			if len(logs) > 0 {
+				for _, s := range subsLogs {
+					matchedLogs := filterLogs(logs, s.logOpts)
+					if len(matchedLogs) > 0 {
+						// v.logsCh is buffered, use non-blocking send to protect the broker:
+						// timeout preferred instead of default to be able to tolerate slight delays
+						select {
+						case s.logsCh <- logs:
+						case <-time.After(10 * time.Millisecond):
+							eb.l.Warn().Msg("Publishing to Logs channel fall into DEFAULT!")
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// Publish API that EventBroker provides. The Indexer/DB will call this
+// to publish the related event to the subscribers
+func (eb *EventBroker) PublishNewHeads(br *utils.BlockResponse) {
+	eb.publishNewHeadsCh <- br
+}
+
+// Publish API that EventBroker provides. The Indexer/DB will call this
+// to publish the related event to the subscribers
+func (eb *EventBroker) PublishLogs(lr []*utils.LogResponse) {
+	eb.publishLogsCh <- lr
+}
+
+// filterLogs creates a slice of Log Response matching the given criteria.
+func filterLogs(rLogs []*utils.LogResponse, opts utils.LogSubscriptionOptions) []*utils.LogResponse {
+	var ret []*utils.LogResponse
+Logs:
+	for _, log := range rLogs {
+		if len(opts.Address) > 0 && !includes(opts.Address, log.Address) {
+			continue
+		}
+
+		// If the number of filtered topics provided is greater than the amount of topics in logs, skip.
+		if len(opts.Topics) > len(log.Topics) {
+			continue
+		}
+		for i, sub := range opts.Topics {
+			match := len(sub) == 0 // empty rule set == wildcard
+			for _, topic := range sub {
+				if bytes.Equal(log.Topics[i], topic) {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue Logs
+			}
+		}
+		ret = append(ret, log)
+	}
+	return ret
+}
+
+func includes(addresses utils.Addresses, address utils.Address) bool {
+	for _, addr := range addresses {
+		if addr == address {
+			return true
+		}
+	}
+	return false
+}

--- a/rpcnode/github-ethereum-go-ethereum/events/broker_test.go
+++ b/rpcnode/github-ethereum-go-ethereum/events/broker_test.go
@@ -1,0 +1,147 @@
+package eventbroker_test
+
+import (
+	eventbroker "aurora-relayer-go-common/rpcnode/github-ethereum-go-ethereum/events"
+	"aurora-relayer-go-common/utils"
+	"crypto/rand"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	numClients          = 100
+	eventTimeoutSeconds = 5
+)
+
+// Test all the flows of the Broker implementation
+func TestBrokerFlows(t *testing.T) {
+	eb := eventbroker.NewEventBroker()
+	go eb.Start()
+
+	// Handles eventCounter channel to calculate the number of received events (by all clients)
+	rcvEventCounter := 0
+	eventCounterCh := make(chan int)
+	go func() {
+		for range eventCounterCh {
+			rcvEventCounter++
+		}
+	}()
+
+	// Create client and subscribe to the events
+	clientNHSubs := make([]*eventbroker.Subscription, numClients)
+	clientLogSubs := make([]*eventbroker.Subscription, numClients)
+	for i := 0; i < numClients; i++ {
+		clientNHSubs[i], clientLogSubs[i] = createClientAndSubscribe(eb, eventCounterCh)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	//Check if subscriptions OK
+	numSubsNH, numSubsLog := getNumberOfSubscriptions(eb)
+	assert.Equal(t, numSubsNH, numClients)
+	assert.Equal(t, numSubsLog, numClients)
+
+	//Start publishing events
+	sentNumMsgCh := make(chan int)
+	go func() {
+		sentMsgCounter := 0
+		timeout := time.After(eventTimeoutSeconds * time.Second)
+		for {
+			eb.PublishNewHeads(&utils.BlockResponse{
+				Number: utils.IntToUint256(sentMsgCounter),
+			})
+			tmpLRS := make([]*utils.LogResponse, 1)
+			tmpLRS[0] = GenerateLogResponse()
+			eb.PublishLogs(tmpLRS)
+			sentMsgCounter += 1
+
+			time.Sleep(10 * time.Millisecond)
+			select {
+			case <-timeout:
+				sentNumMsgCh <- sentMsgCounter
+				return
+			default:
+			}
+
+		}
+	}()
+
+	// Syncs the end of event dissemination
+	sentEventCounter := <-sentNumMsgCh
+
+	//Check if sent and received event counters OK
+	assert.Equal(t, sentEventCounter*numClients*2, rcvEventCounter)
+
+	// Now unsubscribe
+	for i := 0; i < numClients; i++ {
+		eb.UnsubscribeFromNewHeads(clientNHSubs[i])
+		eb.UnsubscribeFromLogs(clientLogSubs[i])
+	}
+
+	time.Sleep(1 * time.Second)
+
+	//Check if unsubscription OK
+	numSubsNH, numSubsLog = getNumberOfSubscriptions(eb)
+	assert.Equal(t, numSubsNH, 0)
+	assert.Equal(t, numSubsLog, 0)
+
+}
+
+func createClientAndSubscribe(eb *eventbroker.EventBroker, eventCounterCh chan int) (*eventbroker.Subscription, *eventbroker.Subscription) {
+	clientNHCh := make(chan *utils.BlockResponse)
+	subsNH := eb.SubscribeNewHeads(clientNHCh)
+
+	clientLogCh := make(chan []*utils.LogResponse)
+	subsLog := eb.SubscribeLogs(utils.LogSubscriptionOptions{}, clientLogCh)
+
+	go func() {
+		for {
+			select {
+			case <-clientNHCh:
+				eventCounterCh <- 1
+			case <-clientLogCh:
+				eventCounterCh <- 1
+			}
+		}
+	}()
+
+	return subsNH, subsLog
+}
+
+func getNumberOfSubscriptions(eb *eventbroker.EventBroker) (int, int) {
+	eb.DebugInfo <- -1
+	numSubsNH := <-eb.DebugInfo
+	eb.DebugInfo <- -2
+	numSubsLog := <-eb.DebugInfo
+
+	return numSubsNH, numSubsLog
+}
+
+func GenerateLogResponse() *utils.LogResponse {
+	return &utils.LogResponse{
+		Address: randomAddress(),
+		Topics:  []utils.Bytea{randomBytea()},
+	}
+}
+
+func randomAddress() utils.Address {
+	return utils.Address{Address: common.BigToAddress(big.NewInt(0).SetBytes(randomBytes(20)))}
+}
+
+func randomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func randomBytea() utils.Bytea {
+	return utils.Bytea(randomBytes(10))
+}

--- a/utils/types.go
+++ b/utils/types.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fxamacker/cbor/v2"
 	"math/big"
 	"strings"
+
+	"github.com/fxamacker/cbor/v2"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -82,6 +83,11 @@ type Log struct {
 	Address Address  `cbor:"Address"`
 	Topics  []Bytea  `cbor:"Topics"`
 	Data    Bytea    `cbor:"data"`
+}
+
+type LogSubscriptionOptions struct {
+	Address Addresses `json:"address"`
+	Topics  Topics    `json:"topics"`
 }
 
 type FilterOptions struct {


### PR DESCRIPTION
This PR implements event subscription and publish mechanism for geth-rpc node. The PR covers the following items.

- Event broker to broadcast the published events. This broker is designed for geth-rpcnode. 
- WS config removed from default config to be able to start node without WS support.
- rpcnode creation updated to support eventbroker. Please note that event broker only started if node supports websocket comm.
- Required LogSubscriptionOptions type added to the types.go