### PR TITLE
(#4) extract broker interface

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -1,0 +1,23 @@
+package broker
+
+import (
+	"aurora-relayer-go-common/utils"
+)
+
+type SubID string
+
+type Subscription interface {
+	GetId() SubID
+	GetNewHeadsCh() chan *utils.BlockResponse
+	GetLogsCh() chan []*utils.LogResponse
+	GetLogsSubOpts() utils.LogSubscriptionOptions
+}
+
+type Broker interface {
+	SubscribeNewHeads(chan *utils.BlockResponse) Subscription
+	SubscribeLogs(utils.LogSubscriptionOptions, chan []*utils.LogResponse) Subscription
+	UnsubscribeFromNewHeads(Subscription)
+	UnsubscribeFromLogs(Subscription)
+	PublishNewHeads(*utils.BlockResponse)
+	PublishLogs([]*utils.LogResponse)
+}

--- a/rpcnode/github-ethereum-go-ethereum/events/broker.go
+++ b/rpcnode/github-ethereum-go-ethereum/events/broker.go
@@ -1,6 +1,7 @@
 package eventbroker
 
 import (
+	"aurora-relayer-go-common/broker"
 	"aurora-relayer-go-common/log"
 	"aurora-relayer-go-common/utils"
 	"bytes"
@@ -12,9 +13,9 @@ import (
 type Type byte
 
 const (
-	// logsChSize is the size of channel listening to Logs event.
+	// LogsChSize is the size of channel listening to Logs event.
 	LogsChSize = 5
-	// newHeadsChSize is the size of channel listening to NewHeads event.
+	// NewHeadsChSize is the size of channel listening to NewHeads event.
 	NewHeadsChSize = 5
 )
 
@@ -27,13 +28,33 @@ const (
 	LogsSubscription
 )
 
-type Subscription struct {
+type EventSubscription struct {
 	id         rpc.ID
 	typ        Type
 	created    time.Time
 	logOpts    utils.LogSubscriptionOptions
 	newHeadsCh chan *utils.BlockResponse
 	logsCh     chan []*utils.LogResponse
+}
+
+// GetId returns identifier of the EventSubscription which implements broker.Subscription
+func (es *EventSubscription) GetId() broker.SubID {
+	return broker.SubID(es.id)
+}
+
+// GetLogsSubOpts returns log filters of the EventSubscription which implements broker.Subscription
+func (es *EventSubscription) GetLogsSubOpts() utils.LogSubscriptionOptions {
+	return es.logOpts
+}
+
+// GetNewHeadsCh returns the newHeads event channel of the EventSubscription which implements broker.Subscription
+func (es *EventSubscription) GetNewHeadsCh() chan *utils.BlockResponse {
+	return es.newHeadsCh
+}
+
+// GetLogsCh returns the logs event channel of the EventSubscription which implements broker.Subscription
+func (es *EventSubscription) GetLogsCh() chan []*utils.LogResponse {
+	return es.logsCh
 }
 
 // EventBroker offers support to manage event subscriptions and broadcast the incoming events to
@@ -43,32 +64,32 @@ type EventBroker struct {
 	stopCh            chan bool
 	publishNewHeadsCh chan *utils.BlockResponse
 	publishLogsCh     chan []*utils.LogResponse
-	subNewHeadsCh     chan *Subscription
-	subLogsCh         chan *Subscription
-	unsubNewHeadsCh   chan *Subscription
-	unsubLogsCh       chan *Subscription
+	subNewHeadsCh     chan broker.Subscription
+	subLogsCh         chan broker.Subscription
+	unsubNewHeadsCh   chan broker.Subscription
+	unsubLogsCh       chan broker.Subscription
 	DebugInfo         chan int
 }
 
-// Creates a new EventsForGoEth object
+// NewEventBroker creates a new EventsForGoEth object
 func NewEventBroker() *EventBroker {
 	return &EventBroker{
 		l:                 log.Log(),
 		stopCh:            make(chan bool, 1),
 		publishNewHeadsCh: make(chan *utils.BlockResponse, NewHeadsChSize),
 		publishLogsCh:     make(chan []*utils.LogResponse, LogsChSize),
-		subNewHeadsCh:     make(chan *Subscription),
-		subLogsCh:         make(chan *Subscription),
-		unsubNewHeadsCh:   make(chan *Subscription),
-		unsubLogsCh:       make(chan *Subscription),
+		subNewHeadsCh:     make(chan broker.Subscription),
+		subLogsCh:         make(chan broker.Subscription),
+		unsubNewHeadsCh:   make(chan broker.Subscription),
+		unsubLogsCh:       make(chan broker.Subscription),
 		DebugInfo:         make(chan int),
 	}
 }
 
 // SubscribeNewHeads creates a new subscription and signals the
 // EventBroker subscription channel to handle the subscription map
-func (eb *EventBroker) SubscribeNewHeads(ch chan *utils.BlockResponse) *Subscription {
-	sub := &Subscription{
+func (eb *EventBroker) SubscribeNewHeads(ch chan *utils.BlockResponse) broker.Subscription {
+	sub := &EventSubscription{
 		id:         rpc.NewID(),
 		typ:        NewHeadsSubscription,
 		created:    time.Now(),
@@ -82,8 +103,8 @@ func (eb *EventBroker) SubscribeNewHeads(ch chan *utils.BlockResponse) *Subscrip
 
 // SubscribeLogs creates a new subscription and signals the
 // EventBroker subscription channel to handle the subscription map
-func (eb *EventBroker) SubscribeLogs(opts utils.LogSubscriptionOptions, ch chan []*utils.LogResponse) *Subscription {
-	sub := &Subscription{
+func (eb *EventBroker) SubscribeLogs(opts utils.LogSubscriptionOptions, ch chan []*utils.LogResponse) broker.Subscription {
+	sub := &EventSubscription{
 		id:         rpc.NewID(),
 		typ:        LogsSubscription,
 		created:    time.Now(),
@@ -98,22 +119,22 @@ func (eb *EventBroker) SubscribeLogs(opts utils.LogSubscriptionOptions, ch chan 
 
 // UnsubscribeFromNewHeads signals the EventBroker's related channel
 // to delete the subscription
-func (eb *EventBroker) UnsubscribeFromNewHeads(sub *Subscription) {
+func (eb *EventBroker) UnsubscribeFromNewHeads(sub broker.Subscription) {
 	eb.unsubNewHeadsCh <- sub
-	eb.l.Info().Msgf("unsubscription request to New Heads with Id: [%s]", sub.id)
+	eb.l.Info().Msgf("unsubscription request to New Heads with Id: [%s]", sub.GetId())
 }
 
 // UnsubscribeFromLogs signals the EventBroker's related channel
 // to delete the subscription
-func (eb *EventBroker) UnsubscribeFromLogs(sub *Subscription) {
+func (eb *EventBroker) UnsubscribeFromLogs(sub broker.Subscription) {
 	eb.unsubLogsCh <- sub
-	eb.l.Info().Msgf("unsubscription request to Logs with Id: [%s]", sub.id)
+	eb.l.Info().Msgf("unsubscription request to Logs with Id: [%s]", sub.GetId())
 }
 
-// This is the main loop of the EventBroker that receives and distributes the events.
+// Start main loop of the EventBroker that receives and distributes the events.
 func (eb *EventBroker) Start() {
-	subsNewHeads := map[rpc.ID]*Subscription{}
-	subsLogs := map[rpc.ID]*Subscription{}
+	subsNewHeads := map[broker.SubID]broker.Subscription{}
+	subsLogs := map[broker.SubID]broker.Subscription{}
 	for {
 		select {
 		case <-eb.stopCh:
@@ -127,19 +148,19 @@ func (eb *EventBroker) Start() {
 				eb.DebugInfo <- len(subsLogs)
 			}
 		case sub := <-eb.subNewHeadsCh:
-			subsNewHeads[sub.id] = sub
+			subsNewHeads[sub.GetId()] = sub
 		case sub := <-eb.subLogsCh:
-			subsLogs[sub.id] = sub
+			subsLogs[sub.GetId()] = sub
 		case sub := <-eb.unsubNewHeadsCh:
-			delete(subsNewHeads, sub.id)
+			delete(subsNewHeads, sub.GetId())
 		case sub := <-eb.unsubLogsCh:
-			delete(subsLogs, sub.id)
+			delete(subsLogs, sub.GetId())
 		case msg := <-eb.publishNewHeadsCh:
 			for _, v := range subsNewHeads {
 				// v.newHeadsCh is buffered, use non-blocking send to protect the broker:
 				// timeout preferred instead of default to be able to tolerate slight delays
 				select {
-				case v.newHeadsCh <- msg:
+				case v.GetNewHeadsCh() <- msg:
 				case <-time.After(10 * time.Millisecond):
 					eb.l.Warn().Msg("Publishing to New Heads channel fall into DEFAULT!")
 				}
@@ -147,12 +168,12 @@ func (eb *EventBroker) Start() {
 		case logs := <-eb.publishLogsCh:
 			if len(logs) > 0 {
 				for _, s := range subsLogs {
-					matchedLogs := filterLogs(logs, s.logOpts)
+					matchedLogs := filterLogs(logs, s.GetLogsSubOpts())
 					if len(matchedLogs) > 0 {
 						// v.logsCh is buffered, use non-blocking send to protect the broker:
 						// timeout preferred instead of default to be able to tolerate slight delays
 						select {
-						case s.logsCh <- logs:
+						case s.GetLogsCh() <- logs:
 						case <-time.After(10 * time.Millisecond):
 							eb.l.Warn().Msg("Publishing to Logs channel fall into DEFAULT!")
 						}
@@ -163,35 +184,33 @@ func (eb *EventBroker) Start() {
 	}
 }
 
-// Publish API that EventBroker provides. The Indexer/DB will call this
-// to publish the related event to the subscribers
+// PublishNewHeads provides publish API for new block head event. Implements broker.Broker interface
 func (eb *EventBroker) PublishNewHeads(br *utils.BlockResponse) {
 	eb.publishNewHeadsCh <- br
 }
 
-// Publish API that EventBroker provides. The Indexer/DB will call this
-// to publish the related event to the subscribers
+// PublishLogs provides publish API for logs event. Implements broker.Broker interface
 func (eb *EventBroker) PublishLogs(lr []*utils.LogResponse) {
 	eb.publishLogsCh <- lr
 }
 
 // filterLogs creates a slice of Log Response matching the given criteria.
-func filterLogs(rLogs []*utils.LogResponse, opts utils.LogSubscriptionOptions) []*utils.LogResponse {
+func filterLogs(logResponses []*utils.LogResponse, opts utils.LogSubscriptionOptions) []*utils.LogResponse {
 	var ret []*utils.LogResponse
 Logs:
-	for _, log := range rLogs {
-		if len(opts.Address) > 0 && !includes(opts.Address, log.Address) {
+	for _, logResponse := range logResponses {
+		if len(opts.Address) > 0 && !includes(opts.Address, logResponse.Address) {
 			continue
 		}
 
 		// If the number of filtered topics provided is greater than the amount of topics in logs, skip.
-		if len(opts.Topics) > len(log.Topics) {
+		if len(opts.Topics) > len(logResponse.Topics) {
 			continue
 		}
 		for i, sub := range opts.Topics {
 			match := len(sub) == 0 // empty rule set == wildcard
 			for _, topic := range sub {
-				if bytes.Equal(log.Topics[i], topic) {
+				if bytes.Equal(logResponse.Topics[i], topic) {
 					match = true
 					break
 				}
@@ -200,7 +219,7 @@ Logs:
 				continue Logs
 			}
 		}
-		ret = append(ret, log)
+		ret = append(ret, logResponse)
 	}
 	return ret
 }

--- a/rpcnode/github-ethereum-go-ethereum/events/broker_test.go
+++ b/rpcnode/github-ethereum-go-ethereum/events/broker_test.go
@@ -1,6 +1,7 @@
 package eventbroker_test
 
 import (
+	"aurora-relayer-go-common/broker"
 	eventbroker "aurora-relayer-go-common/rpcnode/github-ethereum-go-ethereum/events"
 	"aurora-relayer-go-common/utils"
 	"crypto/rand"
@@ -32,8 +33,8 @@ func TestBrokerFlows(t *testing.T) {
 	}()
 
 	// Create client and subscribe to the events
-	clientNHSubs := make([]*eventbroker.Subscription, numClients)
-	clientLogSubs := make([]*eventbroker.Subscription, numClients)
+	clientNHSubs := make([]broker.Subscription, numClients)
+	clientLogSubs := make([]broker.Subscription, numClients)
 	for i := 0; i < numClients; i++ {
 		clientNHSubs[i], clientLogSubs[i] = createClientAndSubscribe(eb, eventCounterCh)
 		time.Sleep(1 * time.Millisecond)
@@ -41,12 +42,12 @@ func TestBrokerFlows(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	//Check if subscriptions OK
+	// Check if subscriptions OK
 	numSubsNH, numSubsLog := getNumberOfSubscriptions(eb)
 	assert.Equal(t, numSubsNH, numClients)
 	assert.Equal(t, numSubsLog, numClients)
 
-	//Start publishing events
+	// Start publishing events
 	sentNumMsgCh := make(chan int)
 	go func() {
 		sentMsgCounter := 0
@@ -74,7 +75,7 @@ func TestBrokerFlows(t *testing.T) {
 	// Syncs the end of event dissemination
 	sentEventCounter := <-sentNumMsgCh
 
-	//Check if sent and received event counters OK
+	// Check if sent and received event counters OK
 	assert.Equal(t, sentEventCounter*numClients*2, rcvEventCounter)
 
 	// Now unsubscribe
@@ -85,14 +86,14 @@ func TestBrokerFlows(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	//Check if unsubscription OK
+	// Check if unsubscription OK
 	numSubsNH, numSubsLog = getNumberOfSubscriptions(eb)
 	assert.Equal(t, numSubsNH, 0)
 	assert.Equal(t, numSubsLog, 0)
 
 }
 
-func createClientAndSubscribe(eb *eventbroker.EventBroker, eventCounterCh chan int) (*eventbroker.Subscription, *eventbroker.Subscription) {
+func createClientAndSubscribe(eb *eventbroker.EventBroker, eventCounterCh chan int) (broker.Subscription, broker.Subscription) {
 	clientNHCh := make(chan *utils.BlockResponse)
 	subsNH := eb.SubscribeNewHeads(clientNHCh)
 

--- a/rpcnode/github-ethereum-go-ethereum/rpcnode.go
+++ b/rpcnode/github-ethereum-go-ethereum/rpcnode.go
@@ -17,6 +17,7 @@
 package github_ethereum_go_ethereum
 
 import (
+	"aurora-relayer-go-common/broker"
 	eventbroker "aurora-relayer-go-common/rpcnode/github-ethereum-go-ethereum/events"
 
 	"github.com/ethereum/go-ethereum/node"
@@ -26,7 +27,7 @@ import (
 // GoEthereum is a container on which underlying go-ethereum services can be registered.
 type GoEthereum struct {
 	node.Node
-	EventBroker *eventbroker.EventBroker
+	Broker broker.Broker
 }
 
 // New creates a new node with default config
@@ -50,8 +51,8 @@ func NewWithConf(conf *Config) (*GoEthereum, error) {
 	}
 
 	return &GoEthereum{
-		Node:        *n,
-		EventBroker: eb,
+		Node:   *n,
+		Broker: eb,
 	}, nil
 }
 


### PR DESCRIPTION
broker and subscription interfaces are created.
Event publishers(e.g.: indexer) and subscribers(e.g.: endpoint) should depend on these interfaces instead of concrete implementations which are subject to change w.r.t. underlying json-rpc server implementation/selection
