### PR TITLE
27: CLI improvements

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 const (
-	defaultConfigName = "relayer"
-	envPrefix         = "AURORA_RELAYER"
+	envPrefix = "AURORA_RELAYER"
 )
 
 func RootCmd() *cobra.Command {
@@ -15,8 +16,8 @@ func RootCmd() *cobra.Command {
 		Use:   "relayer",
 		Short: "Aurora Relayer Implementation",
 		Long:  `A JSON-RPC server implementation compatible with Ethereum's Web3 API for Aurora Engine instances deployed on the NEAR Protocol`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return bind(cmd)
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			bindRootViper()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.OutOrStdout()
@@ -26,37 +27,16 @@ func RootCmd() *cobra.Command {
 	return rootCmd
 }
 
-func bind(_ *cobra.Command) error {
-	viper.SetConfigName(defaultConfigName)
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("/home/altug/repo/aurora-relayer-go")
-	viper.SetEnvPrefix(envPrefix)
+func bindRootViper() {
 	viper.AutomaticEnv()
-	viper.WatchConfig()
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return err
-		}
-	}
-
-	return nil
+	viper.SetEnvPrefix(envPrefix)
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 }
 
-// TODO flag and env binding
-// func bindFlags(cmd *cobra.Command, v *viper.Viper) {
-// 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-// 		// Environment variables can't have dashes in them, so bind them to their equivalent
-// 		if strings.Contains(f.Name, "-") {
-// 			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
-// 			v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
-// 		}
-//
-// 		// Apply the viper config value to the flag when the flag is not set and viper has a value
-// 		if !f.Changed && v.IsSet(f.Name) {
-// 			val := v.Get(f.Name)
-// 			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
-// 		}
-// 	})
-// }
+// BindSubViper is a work around because of a Viper limitation (spf13/viper#507)
+// This work around allows environment variables to be used with sub configs as well.
+func BindSubViper(sub *viper.Viper, subConfigPath string) {
+	sub.AutomaticEnv()
+	sub.SetEnvPrefix(envPrefix + "_" + subConfigPath)
+	sub.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,13 +1,45 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	defaultConfigFile = "config/testnet.yaml"
+)
 
 func StartCmd(f func(cmd *cobra.Command, args []string)) *cobra.Command {
-	return &cobra.Command{
-		Use:   "start",
-		Short: "starts Aurora Relayer",
+
+	startCmd := &cobra.Command{
+		Use:     "start",
+		Aliases: []string{"s"},
+		Short:   "Starts Aurora Relayer",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return bindConfiguration(cmd)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			f(cmd, args)
 		},
 	}
+	startCmd.PersistentFlags().StringP("config", "c", "", "Path of the configuration file (default -> config/testnet.yaml)")
+	return startCmd
+}
+
+func bindConfiguration(cmd *cobra.Command) error {
+	configFile, _ := cmd.Flags().GetString("config")
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	} else {
+		viper.SetConfigFile(defaultConfigFile)
+	}
+
+	viper.WatchConfig()
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,18 +1,33 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"runtime/debug"
 
-const (
-	version = "v 0.1.0"
+	"github.com/spf13/cobra"
 )
 
-func VersionCmd(f func(cmd *cobra.Command, args []string)) *cobra.Command {
+var versionInfo = ""
+
+var buildInfo = func() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return info.String()
+	}
+	return "Build info not available"
+}()
+
+func VersionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "command to manage/display config",
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "Command to display version and build information",
 		Run: func(cmd *cobra.Command, args []string) {
-			f(cmd, args)
-			println("lib: ", version)
+			if versionInfo != "" {
+				fmt.Println("Version:\t", versionInfo)
+				println("")
+			}
+			println("Build Info:")
+			println(buildInfo)
 		},
 	}
 }

--- a/db/badger/config.go
+++ b/db/badger/config.go
@@ -1,8 +1,10 @@
 package badger
 
 import (
+	"aurora-relayer-go-common/cmd"
 	"aurora-relayer-go-common/db/badger/core"
 	"aurora-relayer-go-common/log"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/spf13/viper"
 )
@@ -70,6 +72,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&config); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())

--- a/db/nats/config.go
+++ b/db/nats/config.go
@@ -1,7 +1,9 @@
 package nats
 
 import (
+	"aurora-relayer-go-common/cmd"
 	"aurora-relayer-go-common/log"
+
 	"github.com/nats-io/nats.go"
 	"github.com/spf13/viper"
 )
@@ -31,6 +33,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&config); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())

--- a/endpoint/config.go
+++ b/endpoint/config.go
@@ -1,6 +1,7 @@
 package endpoint
 
 import (
+	"aurora-relayer-go-common/cmd"
 	"aurora-relayer-go-common/log"
 	"aurora-relayer-go-common/utils"
 	"fmt"
@@ -112,6 +113,7 @@ func GetConfig() *Config {
 	c := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&c); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())

--- a/log/config.go
+++ b/log/config.go
@@ -1,6 +1,10 @@
 package log
 
-import "github.com/spf13/viper"
+import (
+	"aurora-relayer-go-common/cmd"
+
+	"github.com/spf13/viper"
+)
 
 const (
 	defaultLogFilePath = "/tmp/relayer/log/relayer.log"
@@ -31,6 +35,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		_ = sub.Unmarshal(&config)
 	}
 	return config

--- a/rpcnode/github-ethereum-go-ethereum/config.go
+++ b/rpcnode/github-ethereum-go-ethereum/config.go
@@ -17,6 +17,7 @@
 package github_ethereum_go_ethereum
 
 import (
+	"aurora-relayer-go-common/cmd"
 	"aurora-relayer-go-common/log"
 
 	gel "github.com/ethereum/go-ethereum/log"
@@ -130,6 +131,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&config); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())

--- a/rpcnode/github-neonxp-jsonrpc2/config.go
+++ b/rpcnode/github-neonxp-jsonrpc2/config.go
@@ -1,7 +1,9 @@
 package github_neonxp_jsonrpc2
 
 import (
+	"aurora-relayer-go-common/cmd"
 	"aurora-relayer-go-common/log"
+
 	"github.com/spf13/viper"
 )
 
@@ -28,6 +30,7 @@ func GetConfig() *Config {
 	config := defaultConfig()
 	sub := viper.Sub(configPath)
 	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
 		if err := sub.Unmarshal(&config); err != nil {
 			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
 				"falling back to defaults", configPath, viper.ConfigFileUsed())


### PR DESCRIPTION
* Persistent CLI `--config` flag added to the `start` command to provide path of the configuration file. If the flag not provided, default is `config/testnet.yaml`
* Local `versionInfo` variable is defined to store application version if provided with a linkler flag while building.
a sample linker flag application is as follows (package info and variable to change is required)
`go build -v -ldflags="-X 'aurora-relayer-go-common/cmd.versionInfo=v1.0.0'"`
* `VersionCmd` is updated to support the build info. Go v1.18+ supports many VCS including `git` to embed the build time, revision etc... Build info also includes all dependency versions and many more
* Viper Environment Key support enabled. Eg: To set the `endpoint.engine.signer` config value, `AURORA_RELAYER_ENDPOINT_ENGINE_SIGNER` env variable can be set. Here,  `AURORA_RELAYER` env key prefix is used to differentiate project specific keys 
