### PR TITLE
34: Add support for missing endpoints

### DIFF
--- a/endpoint/config.go
+++ b/endpoint/config.go
@@ -22,9 +22,11 @@ const (
 )
 
 type EthConfig struct {
-	protocolVersion common.Uint256 `mapstructure:"protocolVersion"`
-	hashrate        common.Uint256 `mapstructure:"hashrate"`
-	zeroAddress     string         `mapstructure:"zeroAddress"`
+	ProtocolVersion common.Uint256 `mapstructure:"protocolVersion"`
+	Hashrate        common.Uint256 `mapstructure:"hashrate"`
+	GasEstimate     common.Uint256 `mapstructure:"gasEstimate"`
+	GasPrice        common.Uint256 `mapstructure:"gasPrice"`
+	ZeroAddress     string         `mapstructure:"zeroAddress"`
 }
 
 type Config struct {
@@ -36,9 +38,11 @@ type Config struct {
 }
 
 type ethConfig struct {
-	protocolVersion int `mapstructure:"protocolVersion"`
-	hashrate        int `mapstructure:"hashrate"`
-	zeroAddress     int `mapstructure:"zeroAddress"`
+	ProtocolVersion int `mapstructure:"protocolVersion"`
+	Hashrate        int `mapstructure:"hashrate"`
+	GasEstimate     int `mapstructure:"gasEstimate"`
+	GasPrice        int `mapstructure:"gasPrice"`
+	ZeroAddress     int `mapstructure:"zeroAddress"`
 }
 
 type EngineConfig struct {
@@ -89,9 +93,11 @@ func defaultConfig() *config {
 		},
 		DisabledEndpoints: []string{},
 		EthConfig: ethConfig{
-			protocolVersion: 0x41,
-			hashrate:        0,
-			zeroAddress:     0,
+			ProtocolVersion: 0x41,
+			Hashrate:        0,
+			GasEstimate:     0x6691b7,
+			GasPrice:        0x42c1d80,
+			ZeroAddress:     0,
 		},
 		EngineConfig: engineConfig{
 			NearNetworkID:                 "",
@@ -122,9 +128,11 @@ func GetConfig() *Config {
 
 	config := &Config{
 		EthConfig: EthConfig{
-			protocolVersion: common.IntToUint256(c.EthConfig.protocolVersion),
-			hashrate:        common.IntToUint256(c.EthConfig.hashrate),
-			zeroAddress:     fmt.Sprintf("0x%040x", c.EthConfig.zeroAddress),
+			ProtocolVersion: common.IntToUint256(c.EthConfig.ProtocolVersion),
+			Hashrate:        common.IntToUint256(c.EthConfig.Hashrate),
+			GasEstimate:     common.IntToUint256(c.EthConfig.GasEstimate),
+			GasPrice:        common.IntToUint256(c.EthConfig.GasPrice),
+			ZeroAddress:     fmt.Sprintf("0x%040x", c.EthConfig.ZeroAddress),
 		},
 		EngineConfig: EngineConfig{
 			NearNetworkID:                 c.EngineConfig.NearNetworkID,

--- a/endpoint/ethProcessorAware.go
+++ b/endpoint/ethProcessorAware.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"aurora-relayer-go-common/types/common"
+	"aurora-relayer-go-common/types/engine"
 	"aurora-relayer-go-common/types/primitives"
 	"aurora-relayer-go-common/types/request"
 	"aurora-relayer-go-common/types/response"
@@ -83,7 +84,7 @@ func (e *EthProcessorAware) GetBlockTransactionCountByNumber(ctx context.Context
 }
 
 func (e *EthProcessorAware) GetTransactionByHash(ctx context.Context, hash common.H256) (*response.Transaction, error) {
-	return Process(ctx, "eth_GetTransactionByHash", e.Endpoint, func(ctx context.Context) (*response.Transaction, error) {
+	return Process(ctx, "eth_getTransactionByHash", e.Endpoint, func(ctx context.Context) (*response.Transaction, error) {
 		return e.Eth.GetTransactionByHash(ctx, hash)
 	}, hash)
 }
@@ -119,37 +120,79 @@ func (e *EthProcessorAware) GetFilterLogs(ctx context.Context, filterId common.U
 }
 
 func (e *EthProcessorAware) GetUncleCountByBlockHash(ctx context.Context, hash common.H256) (*common.Uint256, error) {
-	return Process(ctx, "eth_GetUncleCountByBlockHash", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_getUncleCountByBlockHash", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.GetUncleCountByBlockHash(ctx, hash)
 	}, hash)
 }
 
 func (e *EthProcessorAware) GetUncleCountByBlockNumber(ctx context.Context, number common.BN64) (*common.Uint256, error) {
-	return Process(ctx, "eth_GetUncleCountByBlockNumber", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_getUncleCountByBlockNumber", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.GetUncleCountByBlockNumber(ctx, number)
 	}, number)
 }
 
+func (e *EthProcessorAware) GetUncleByBlockHashAndIndex(ctx context.Context, hash common.H256, index common.Uint64) (*string, error) {
+	return Process(ctx, "eth_getUncleCountByHashAndIndex", e.Endpoint, func(ctx context.Context) (*string, error) {
+		return e.Eth.GetUncleByBlockHashAndIndex(ctx, hash, index)
+	}, hash, index)
+}
+
+func (e *EthProcessorAware) GetUncleByBlockNumberAndIndex(ctx context.Context, number common.BN64, index common.Uint64) (*string, error) {
+	return Process(ctx, "eth_getUncleByBlockNumberAndIndex", e.Endpoint, func(ctx context.Context) (*string, error) {
+		return e.Eth.GetUncleByBlockNumberAndIndex(ctx, number, index)
+	}, number, index)
+}
+
 func (e *EthProcessorAware) NewFilter(ctx context.Context, filter request.Filter) (*common.Uint256, error) {
-	return Process(ctx, "eth_NewFilter", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_newFilter", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.NewFilter(ctx, filter)
 	}, filter)
 }
 
 func (e *EthProcessorAware) NewBlockFilter(ctx context.Context) (*common.Uint256, error) {
-	return Process(ctx, "eth_NewBlockFilter", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_newBlockFilter", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.NewBlockFilter(ctx)
 	})
 }
 
+func (e *EthProcessorAware) NewPendingTransactionFilter(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_newBlockFilter", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+		return e.Eth.NewPendingTransactionFilter(ctx)
+	})
+}
+
 func (e *EthProcessorAware) UninstallFilter(ctx context.Context, filterId common.Uint256) (*bool, error) {
-	return Process(ctx, "eth_UninstallFilter", e.Endpoint, func(ctx context.Context) (*bool, error) {
+	return Process(ctx, "eth_uninstallFilter", e.Endpoint, func(ctx context.Context) (*bool, error) {
 		return e.Eth.UninstallFilter(ctx, filterId)
 	}, filterId)
 }
 
 func (e *EthProcessorAware) GetFilterChanges(ctx context.Context, filterId common.Uint256) (*[]interface{}, error) {
-	return Process(ctx, "eth_GetFilterChanges", e.Endpoint, func(ctx context.Context) (*[]interface{}, error) {
+	return Process(ctx, "eth_getFilterChanges", e.Endpoint, func(ctx context.Context) (*[]interface{}, error) {
 		return e.Eth.GetFilterChanges(ctx, filterId)
 	}, filterId)
+}
+
+func (e *EthProcessorAware) GetCompilers(ctx context.Context) (*[]string, error) {
+	return Process(ctx, "eth_getCompilers", e.Endpoint, func(ctx context.Context) (*[]string, error) {
+		return e.Eth.GetCompilers(ctx)
+	})
+}
+
+func (e *EthProcessorAware) PendingTransactions(ctx context.Context) (*[]string, error) {
+	return Process(ctx, "eth_pendingTransactions", e.Endpoint, func(ctx context.Context) (*[]string, error) {
+		return e.Eth.PendingTransactions(ctx)
+	})
+}
+
+func (e *EthProcessorAware) EstimateGas(ctx context.Context, txs engine.TransactionForCall, number *common.BN64) (*common.Uint256, error) {
+	return Process(ctx, "eth_estimateGas", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+		return e.Eth.EstimateGas(ctx, txs, number)
+	}, txs, number)
+}
+
+func (e *EthProcessorAware) GasPrice(ctx context.Context) (*common.Uint256, error) {
+	return Process(ctx, "eth_estimateGas", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
+		return e.Eth.GasPrice(ctx)
+	})
 }

--- a/endpoint/net.go
+++ b/endpoint/net.go
@@ -6,15 +6,15 @@ import (
 
 var (
 	peerCount = "0x0"
-	listening = false
+	listening = true
 )
 
 type Net struct {
 	*Endpoint
 }
 
-func NewNet(endpoint *Endpoint) *Eth {
-	return &Eth{endpoint}
+func NewNet(endpoint *Endpoint) *Net {
+	return &Net{endpoint}
 }
 
 // Listening always returns true on success

--- a/endpoint/web3.go
+++ b/endpoint/web3.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	clientVersion = "Aurora Relayer"
+	clientVersion = "Aurora"
 )
 
 type Web3 struct {


### PR DESCRIPTION
- Adds missing APIs
  * eth_estimateGas - returns constant value
  * eth_gasPrice - returns constant value
  * eth_getCompilers - returns empty list
  * eth_getUncleByBlockHashAndIndex and eth_getUncleByBlockNumberAndIndex - return null since uncle blocks are never found
  * eth_newPendingTransactionFilter - returns zero value
  * eth_pendingTransactions - returns empty array
- Fixes the update issue in `ethConfig` settings and adds `gasPrice` and `gasEstimate` configs
- Minor fixes on `net_` and `web3_` endpoints