### PR TITLE
47: Endpoint improvements

### DIFF
--- a/endpoint/eth.go
+++ b/endpoint/eth.go
@@ -322,14 +322,14 @@ func (e *Eth) GetFilterLogs(ctx context.Context, filterId common.Uint256) (*[]*r
 // GetUncleCountByBlockHash returns zero
 //
 // 	If API is disabled, returns errors code '-32601' with message 'the method does not exist/is not available'.
-func (e *Eth) GetUncleCountByBlockHash(_ context.Context, _ common.H256) (*common.Uint256, error) {
+func (e *Eth) GetUncleCountByBlockHash(_ context.Context, _ *common.H256) (*common.Uint256, error) {
 	return &zero, nil
 }
 
 // GetUncleCountByBlockNumber returns zero
 //
 // 	If API is disabled, returns errors code '-32601' with message 'the method does not exist/is not available'.
-func (e *Eth) GetUncleCountByBlockNumber(_ context.Context, _ common.BN64) (*common.Uint256, error) {
+func (e *Eth) GetUncleCountByBlockNumber(_ context.Context, _ *common.BN64) (*common.Uint256, error) {
 	return &zero, nil
 }
 
@@ -337,7 +337,7 @@ func (e *Eth) GetUncleCountByBlockNumber(_ context.Context, _ common.BN64) (*com
 //
 // 	If API is disabled, returns errors code '-32601' with message 'the method does not exist/is not available'.
 // 	On missing or invalid param returns error code '-32602' with custom message.
-func (e *Eth) GetUncleByBlockHashAndIndex(_ context.Context, _ common.H256, _ common.Uint64) (*string, error) {
+func (e *Eth) GetUncleByBlockHashAndIndex(_ context.Context, _ *common.H256, _ *common.Uint64) (*string, error) {
 	return nil, nil
 }
 
@@ -345,7 +345,7 @@ func (e *Eth) GetUncleByBlockHashAndIndex(_ context.Context, _ common.H256, _ co
 //
 // 	If API is disabled, returns errors code '-32601' with message 'the method does not exist/is not available'.
 // 	On missing or invalid param returns error code '-32602' with custom message.
-func (e *Eth) GetUncleByBlockNumberAndIndex(_ context.Context, _ common.BN64, _ common.Uint64) (*string, error) {
+func (e *Eth) GetUncleByBlockNumberAndIndex(_ context.Context, _ *common.BN64, _ *common.Uint64) (*string, error) {
 	return nil, nil
 }
 

--- a/endpoint/ethProcessorAware.go
+++ b/endpoint/ethProcessorAware.go
@@ -119,25 +119,25 @@ func (e *EthProcessorAware) GetFilterLogs(ctx context.Context, filterId common.U
 	}, filterId)
 }
 
-func (e *EthProcessorAware) GetUncleCountByBlockHash(ctx context.Context, hash common.H256) (*common.Uint256, error) {
+func (e *EthProcessorAware) GetUncleCountByBlockHash(ctx context.Context, hash *common.H256) (*common.Uint256, error) {
 	return Process(ctx, "eth_getUncleCountByBlockHash", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.GetUncleCountByBlockHash(ctx, hash)
 	}, hash)
 }
 
-func (e *EthProcessorAware) GetUncleCountByBlockNumber(ctx context.Context, number common.BN64) (*common.Uint256, error) {
+func (e *EthProcessorAware) GetUncleCountByBlockNumber(ctx context.Context, number *common.BN64) (*common.Uint256, error) {
 	return Process(ctx, "eth_getUncleCountByBlockNumber", e.Endpoint, func(ctx context.Context) (*common.Uint256, error) {
 		return e.Eth.GetUncleCountByBlockNumber(ctx, number)
 	}, number)
 }
 
-func (e *EthProcessorAware) GetUncleByBlockHashAndIndex(ctx context.Context, hash common.H256, index common.Uint64) (*string, error) {
+func (e *EthProcessorAware) GetUncleByBlockHashAndIndex(ctx context.Context, hash *common.H256, index *common.Uint64) (*string, error) {
 	return Process(ctx, "eth_getUncleCountByHashAndIndex", e.Endpoint, func(ctx context.Context) (*string, error) {
 		return e.Eth.GetUncleByBlockHashAndIndex(ctx, hash, index)
 	}, hash, index)
 }
 
-func (e *EthProcessorAware) GetUncleByBlockNumberAndIndex(ctx context.Context, number common.BN64, index common.Uint64) (*string, error) {
+func (e *EthProcessorAware) GetUncleByBlockNumberAndIndex(ctx context.Context, number *common.BN64, index *common.Uint64) (*string, error) {
 	return Process(ctx, "eth_getUncleByBlockNumberAndIndex", e.Endpoint, func(ctx context.Context) (*string, error) {
 		return e.Eth.GetUncleByBlockNumberAndIndex(ctx, number, index)
 	}, number, index)

--- a/endpoint/parity.go
+++ b/endpoint/parity.go
@@ -1,0 +1,23 @@
+package endpoint
+
+import (
+	"aurora-relayer-go-common/types/common"
+
+	"golang.org/x/net/context"
+)
+
+type Parity struct {
+	*Endpoint
+}
+
+func NewParity(endpoint *Endpoint) *Parity {
+	return &Parity{endpoint}
+}
+
+// PendingTransactions returns a list of txs currently in the queue.
+// As of now method always returns empty array since the relayer has no txs queue support.
+//
+//	If API is disabled, returns errors code '-32601' with message 'the method does not exist/is not available'.
+func (p *Parity) PendingTransactions(_ context.Context, _ *common.Uint64, _ *interface{}) (*[]string, error) {
+	return &emptyArray, nil
+}

--- a/endpoint/parityProcessorAware.go
+++ b/endpoint/parityProcessorAware.go
@@ -1,0 +1,21 @@
+package endpoint
+
+import (
+	"aurora-relayer-go-common/types/common"
+
+	"golang.org/x/net/context"
+)
+
+type ParityProcessorAware struct {
+	*Parity
+}
+
+func NewParityProcessorAware(p *Parity) *ParityProcessorAware {
+	return &ParityProcessorAware{p}
+}
+
+func (e *ParityProcessorAware) PendingTransactions(ctx context.Context, limit *common.Uint64, filter *interface{}) (*[]string, error) {
+	return Process(ctx, "parity_pendingTransactions", e.Endpoint, func(ctx context.Context) (*[]string, error) {
+		return e.Parity.PendingTransactions(ctx, limit, filter)
+	})
+}

--- a/rpcnode/github-ethereum-go-ethereum/config.go
+++ b/rpcnode/github-ethereum-go-ethereum/config.go
@@ -119,7 +119,7 @@ func defaultConfig() *Config {
 		HTTPHost:         DefaultHost,
 		HTTPPort:         DefaultHTTPPort,
 		HTTPPathPrefix:   DefaultPathPrefix,
-		HTTPModules:      []string{"net", "web3", "eth"},
+		HTTPModules:      []string{"net", "web3", "eth", "parity"},
 		HTTPVirtualHosts: []string{},
 		HTTPCors:         []string{},
 		HTTPTimeouts:     rpc.DefaultHTTPTimeouts,


### PR DESCRIPTION
* parity_PendingTransactions endpoint supported
* Because `GetUncleXXX` endpoints return constant, all of their params converted to optional (similar to infra mainnet)