### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/db/badger/core/indexer.go
+++ b/db/badger/core/indexer.go
@@ -10,5 +10,8 @@ func (txn *ViewTxn) ReadIndexerState(chainId uint64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return data.Bytes(), nil
+	if data != nil {
+		return data.Bytes(), nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
Add a check to ensure that `ReadIndexerState` doesn't derefence a nil pointer when the data returned by `read` is nil.
`read` returns nil data and nil error when the key is not found in the database.