### PR TITLE
DB: use xsync.Map instead of sync.Map for cached reads

### DIFF
--- a/db/badger/core/db.go
+++ b/db/badger/core/db.go
@@ -1,8 +1,10 @@
 package core
 
 import (
-	"github.com/dgraph-io/badger/v3"
 	"relayer2-base/db/codec"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/puzpuzpuz/xsync/v2"
 )
 
 type DB struct {
@@ -40,8 +42,9 @@ func (db *DB) NewWriter() *Writer {
 func (db *DB) View(fn func(txn *ViewTxn) error) error {
 	return db.core.View(func(txn *badger.Txn) error {
 		return fn(&ViewTxn{
-			db:  db,
-			txn: txn,
+			db:    db,
+			txn:   txn,
+			cache: xsync.NewMapOf[*cachedRead](),
 		})
 	})
 }
@@ -49,8 +52,9 @@ func (db *DB) View(fn func(txn *ViewTxn) error) error {
 func (db *DB) Update(fn func(txn *ViewTxn) error) error {
 	return db.core.Update(func(txn *badger.Txn) error {
 		return fn(&ViewTxn{
-			db:  db,
-			txn: txn,
+			db:    db,
+			txn:   txn,
+			cache: xsync.NewMapOf[*cachedRead](),
 		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/near/borsh-go v0.3.1
+	github.com/puzpuzpuz/xsync/v2 v2.4.0
 	github.com/rs/zerolog v1.28.0
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
 github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
+github.com/puzpuzpuz/xsync/v2 v2.4.0 h1:5sXAMHrtx1bg9nbRZTOn8T4MkWe5V+o8yKRH02Eznag=
+github.com/puzpuzpuz/xsync/v2 v2.4.0/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
Recent flame-graph has shown that under certain load cached reads can consume up to 1.32% of CPU load just for `map.LoadOrStore` operations. As a good optimization here, faster implementation of concurrent map - [xsync.MapOf](https://github.com/puzpuzpuz/xsync) can be used.

Apart from speeding up key access, it also allows to only allocate new structure and `ready` channel inside it only when it's indeed needed by using `LoadOrCompute` instead of `LoadOrStore` (`runtime.makechan` consumes additional 0.18% of CPU on mentioned flame graph)