### PR TITLE
Refactor concurrent initialization of components

### DIFF
--- a/indexer/prehistory/indexer.go
+++ b/indexer/prehistory/indexer.go
@@ -26,7 +26,7 @@ type Indexer struct {
 	dbh     db.Handler
 	config  *Config
 	logger  *log.Logger
-	lock    *sync.Mutex
+	lock    sync.Mutex
 	started bool
 	stopCh  chan bool
 	reader  PreHistoryReader
@@ -69,7 +69,6 @@ func New(dbh db.Handler) (*Indexer, error) {
 		dbh:    dbh,
 		logger: logger,
 		config: config,
-		lock:   &sync.Mutex{},
 		stopCh: make(chan bool),
 		reader: PreHistoryReader{},
 	}

--- a/syncutils/atomicptr.go
+++ b/syncutils/atomicptr.go
@@ -1,0 +1,26 @@
+package syncutils
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+/*
+	NOTE: This functionality was introduced in std lib of Golang 1.19: https://pkg.go.dev/sync/atomic#Pointer
+*/
+
+type AtomicPtr[T any] struct {
+	ptr *T
+}
+
+func (ap *AtomicPtr[T]) getUnsafePtr() *unsafe.Pointer {
+	return (*unsafe.Pointer)(unsafe.Pointer(&ap.ptr))
+}
+
+func (ap *AtomicPtr[T]) Load() *T {
+	return (*T)(atomic.LoadPointer(ap.getUnsafePtr()))
+}
+
+func (ap *AtomicPtr[T]) Store(val *T) {
+	atomic.StorePointer(ap.getUnsafePtr(), unsafe.Pointer(val))
+}

--- a/syncutils/atomicptr_test.go
+++ b/syncutils/atomicptr_test.go
@@ -1,0 +1,30 @@
+package syncutils
+
+import "testing"
+
+func TestAtomicPtr(t *testing.T) {
+	a := "a"
+	b := "b"
+	c := "c"
+
+	var x AtomicPtr[string]
+
+	if x.Load() != nil {
+		t.Fatalf("x.Load() != nil")
+	}
+
+	x.ptr = &a
+	if x.Load() != &a {
+		t.Fatalf("x.Load() != &a")
+	}
+
+	x.Store(&b)
+	if x.Load() != &b {
+		t.Fatalf("x.Load() != &b")
+	}
+
+	x.Store(&c)
+	if x.ptr != &c {
+		t.Fatalf("x.ptr != &c")
+	}
+}

--- a/syncutils/lockableptr.go
+++ b/syncutils/lockableptr.go
@@ -1,0 +1,40 @@
+package syncutils
+
+import "sync"
+
+type LockablePtr[T any] struct {
+	ptr AtomicPtr[T]
+	mtx sync.Mutex
+}
+
+func (lp *LockablePtr[T]) Load() *T {
+	return lp.ptr.Load()
+}
+
+func (lp *LockablePtr[T]) LockIfNil() (value *T, unlock func(newValue *T)) {
+	if value = lp.Load(); value == nil {
+		lp.mtx.Lock()
+		if value = lp.Load(); value == nil {
+			return value, func(newValue *T) {
+				lp.ptr.Store(newValue)
+				lp.mtx.Unlock()
+			}
+		}
+		lp.mtx.Unlock()
+	}
+	return value, nil
+}
+
+func (lp *LockablePtr[T]) LockIfNotNil() (value *T, unlock func(newValue *T)) {
+	if value = lp.Load(); value != nil {
+		lp.mtx.Lock()
+		if value = lp.Load(); value != nil {
+			return value, func(newValue *T) {
+				lp.ptr.Store(newValue)
+				lp.mtx.Unlock()
+			}
+		}
+		lp.mtx.Unlock()
+	}
+	return value, nil
+}


### PR DESCRIPTION
- Several components have same concurrency flaw on initialization: global pointer is first read in non-safe way ([example](https://github.com/aurora-is-near/relayer2-base/blob/e8892d1c7172d1b4946a1b49492332e8df30e1b9/db/badger/core/core.go#L18)) and only then mutex is taken. In order to fix this, `syncutils.LockablePtr` (combination of atomic-ptr for performant reads and mutex for exclusive write privileges) was introduced
- Misc: `gcStop` channel initialization from [here](https://github.com/aurora-is-near/relayer2-base/blob/e8892d1c7172d1b4946a1b49492332e8df30e1b9/db/badger/core/core.go#L74) was moved to caller function in order to provide guarantee that this channel will be initialized **before** `Close()` will be called.
- Misc: there's no reason to do `var mtx = &sync.Mutex{}`, just `var mtx sync.Mutex` is safe to use and requires no additional pointer

Note: initially I wanted to put `LockablePtr` to `utils` instead of `syncutils`, but that would require `log` package to import `utils` package, which in turn would create import loop: `log -> utils -> types/indexer -> db/codec -> log`