### PR TITLE
Update transaction responses

### DIFF
--- a/db/badger/core/responses.go
+++ b/db/badger/core/responses.go
@@ -74,6 +74,7 @@ func makeTransactionResponse(
 		S:                data.S,
 		TransactionIndex: primitives.HexUint(index),
 		Value:            data.Value,
+		Type:             primitives.HexUint(data.Type),
 	}
 	if !data.IsContractDeployment {
 		tx.To = data.ToOrContract.Ptr
@@ -93,6 +94,9 @@ func makeTransactionResponse(
 		tx.ChainID = &chainId
 		tx.MaxPriorityFeePerGas = &data.MaxPriorityFeePerGas
 		tx.MaxFeePerGas = &data.MaxFeePerGas
+	}
+	if data.Type > 2 {
+		tx.Type = primitives.HexUint(0)
 	}
 
 	return tx
@@ -147,6 +151,7 @@ func makeTransactionReceiptResponse(
 		NearReceiptHash:   txData.NearReceiptHash,
 		TransactionHash:   txHash,
 		TransactionIndex:  primitives.HexUint(txIndex),
+		Type:              primitives.HexUint(txData.Type),
 	}
 	if txData.IsContractDeployment {
 		txReceipt.ContractAddress = txData.ToOrContract.Ptr
@@ -160,6 +165,9 @@ func makeTransactionReceiptResponse(
 	}
 	if txData.NearHash.Ptr != nil {
 		txReceipt.NearTransactionHash = *txData.NearHash.Ptr
+	}
+	if txData.Type > 2 {
+		txReceipt.Type = primitives.HexUint(0)
 	}
 
 	return txReceipt

--- a/types/response/transaction.go
+++ b/types/response/transaction.go
@@ -23,6 +23,7 @@ type Transaction struct {
 	R                    primitives.Quantity  `json:"r"`
 	S                    primitives.Quantity  `json:"s"`
 	To                   *primitives.Data20   `json:"to"`
+	Type                 primitives.HexUint   `json:"type"`
 	TransactionIndex     primitives.HexUint   `json:"transactionIndex"`
 	Value                primitives.Quantity  `json:"value"`
 }

--- a/types/response/transactionreceipt.go
+++ b/types/response/transactionreceipt.go
@@ -19,6 +19,7 @@ type TransactionReceipt struct {
 	NearTransactionHash primitives.Data32   `json:"nearTransactionHash"`
 	Status              primitives.HexUint  `json:"status"`
 	To                  *primitives.Data20  `json:"to"`
+	Type                primitives.HexUint  `json:"type"`
 	TransactionHash     primitives.Data32   `json:"transactionHash"`
 	TransactionIndex    primitives.HexUint  `json:"transactionIndex"`
 }


### PR DESCRIPTION
- Add `type` field to transaction and transaction receipt responses. Value of field can be 0, 1, or 2 and other values are overwritten to be 0. [Transaction type reference](https://docs.infura.io/infura/networks/ethereum/concepts/transaction-types)
- Fix NEAR transaction hash in our transaction receipt response. Previously the saved receipt hash was used for both `NearReceiptHash` and `NearTransactionHash` fields.