### PR TITLE
Update NEAR transaction hash field for indexer

### DIFF
--- a/types/indexer/indexer.go
+++ b/types/indexer/indexer.go
@@ -74,8 +74,8 @@ type AccessList struct {
 }
 
 type NearTransaction struct {
-	Hash        *NearHash `cbor:"hash"         json:"hash"`
-	ReceiptHash NearHash  `cbor:"receipt_hash" json:"receipt_hash"`
+	Hash        *NearHash `cbor:"transaction_hash" json:"transaction_hash"`
+	ReceiptHash NearHash  `cbor:"receipt_hash"     json:"receipt_hash"`
 }
 
 type Log struct {


### PR DESCRIPTION
Updates the indexer types to work with the new version of input.
This change fixes the field name and enables correct unmarshaling of the NEAR transaction hash field.