### PR TITLE
Fix endpoint child context

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -13,7 +13,9 @@ func Process[T any](ctx context.Context, name string, endpoint *Endpoint, handle
 	var resp any
 	var err error
 	var stop bool
-	var childCtx context.Context
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	for _, p := range endpoint.Processors {
 		childCtx, stop, err = p.Pre(ctx, name, endpoint, &resp, args...)


### PR DESCRIPTION
`endpoint.Process()` creates `childCtx` which is `nil` since `context.Context` is an interface.
This fix creates `childCtx` properly and the parent context's `Done` signal is also propagated to the child.