### PR TITLE
97: Implement prehistory DB silo support

### DIFF
--- a/indexer/prehistory/config.go
+++ b/indexer/prehistory/config.go
@@ -11,7 +11,7 @@ const (
 	defaultIndexFromPrehistory = false
 	defaultFromBlock           = 0
 	defaultBatchSize           = 10000
-	defaultChainId             = 1313161554
+	defaultPrehistoryChainId   = 1313161554
 
 	configPath = "prehistoryIndexer"
 )
@@ -23,7 +23,7 @@ type Config struct {
 	To                  uint64 `mapstructure:"to"`
 	ArchiveURL          string `mapstructure:"archiveURL"`
 	BatchSize           uint64 `mapstructure:"batchSize"`
-	ChainId             uint64 `mapstructure:"chainId"`
+	PrehistoryChainId   uint64 `mapstructure:"prehistoryChainId"`
 }
 
 func defaultConfig() *Config {
@@ -31,7 +31,7 @@ func defaultConfig() *Config {
 		IndexFromPrehistory: defaultIndexFromPrehistory,
 		From:                defaultFromBlock,
 		BatchSize:           defaultBatchSize,
-		ChainId:             defaultChainId,
+		PrehistoryChainId:   defaultPrehistoryChainId,
 	}
 }
 

--- a/indexer/prehistory/indexer.go
+++ b/indexer/prehistory/indexer.go
@@ -114,7 +114,7 @@ func (i *Indexer) index() {
 	quantity := primitives.QuantityFromBytes(emptyBytes)
 	parentHash := primitives.Data32FromBytes(emptyBytes)
 	blockHash := primitives.Data32FromBytes(emptyBytes)
-	chainId := i.config.ChainId
+	chainId := i.config.PrehistoryChainId
 	from := i.config.From
 	to := i.config.To
 	step := i.config.BatchSize

--- a/utils/context.go
+++ b/utils/context.go
@@ -8,12 +8,17 @@ import (
 )
 
 const (
-	chainIdConfigPath = "endpoint.chainID"
+	chainIdConfigPath           = "endpoint.chainID"
+	prehistoryChainIdConfigPath = "prehistoryIndexer.prehistoryChainID"
+	prehsitoryHeightConfigPath  = "prehistoryIndexer.prehistoryHeight"
 )
 
 var (
-	defaultChainId uint64 = 1313161554
-	chainId        *uint64
+	defaultChainId          uint64 = 1313161554
+	chainId                 *uint64
+	prehistoryChainId       *uint64
+	defaultPrehistoryHeight uint64 = 37157758
+	prehistoryHeight        *uint64
 )
 
 type chainIdKey struct{}
@@ -51,4 +56,50 @@ func getChainId() *uint64 {
 		cid = &defaultChainId
 	}
 	return cid
+}
+
+// GetPrehistoryChainId returns the chainId config that the prehistory was indexed for;
+//	1. returns prehistoryChainId if exists in relayer configuration .yml file
+//	2. returns defaultChainId=1313161554
+func GetPrehistoryChainId() uint64 {
+	if prehistoryChainId == nil {
+		prehistoryChainId = getPrehistoryChainId()
+	}
+	return *prehistoryChainId
+}
+
+func getPrehistoryChainId() *uint64 {
+	var pcid *uint64
+	sub := viper.GetUint64(prehistoryChainIdConfigPath)
+	if sub != 0 {
+		pcid = &sub
+	} else {
+		log.Log().Warn().Msgf("failed to parse configuration [%s] from [%s], "+
+			"falling back to defaults", prehistoryChainIdConfigPath, viper.ConfigFileUsed())
+		pcid = &defaultChainId
+	}
+	return pcid
+}
+
+// GetPrehistoryHeight returns the height of the prehistory given in relayer configuration .yml file
+//	1. returns prehistoryHeight if exists in relayer configuration .yml file
+//	2. returns defaultPrehistoryHeight=37157758 that is for mainnet
+func GetPrehistoryHeight() uint64 {
+	if prehistoryHeight == nil {
+		prehistoryHeight = getPrehistoryHeight()
+	}
+	return *prehistoryHeight
+}
+
+func getPrehistoryHeight() *uint64 {
+	var ph *uint64
+	sub := viper.GetUint64(prehsitoryHeightConfigPath)
+	if sub != 0 {
+		ph = &sub
+	} else {
+		log.Log().Warn().Msgf("failed to parse configuration [%s] from [%s], "+
+			"falling back to defaults", prehsitoryHeightConfigPath, viper.ConfigFileUsed())
+		ph = &defaultPrehistoryHeight
+	}
+	return ph
 }


### PR DESCRIPTION
 This PR implements the following items
 * `getBlockByNumber` flow updated. If the requested block height belongs to prehistory, then DB search is made for the prehistory chainId (if needed). Also, the block hash and parent hash fields are modified accordingly while returning the block response. 
 * `getBlockByHash` flow updated. First, the provided hash is queried in relayer DB. If there is no hit and the prehistory chain is different than the relayer chain, the provided hash is checked if it is a modified prehistory hash or not. If it is, then, the decoded block height is searched in prehistory DB. Like above, the prehistory block modified accordingly if needed. 
 * The `chainId` item in .yml configurations renamed as `prehistoryChainId`. I believe this way it is more intuitional to configure the prehistory indexing. 
 