### PR TITLE
(#100) provide lib for creating and serving metrics

### DIFF
--- a/probe/config.go
+++ b/probe/config.go
@@ -1,0 +1,64 @@
+package probe
+
+import (
+	"github.com/aurora-is-near/relayer2-base/cmd"
+	"github.com/aurora-is-near/relayer2-base/log"
+	"github.com/spf13/viper"
+)
+
+const (
+	defaultAddress   = "127.0.0.1:28080"
+	defaultNamespace = "Aurora"
+	defaultSubsystem = "Relayer2"
+	defaultEnabled   = false
+
+	configPath = "probe"
+)
+
+type ServerConfig struct {
+	Address   string `mapstructure:"address"`
+	Namespace string `mapstructure:"namespace"`
+	Subsystem string `mapstructure:"subsystem"`
+}
+
+type MetricConfig struct {
+	Id          string    `mapstructure:"id"`
+	Type        string    `mapstructure:"type"`
+	Name        string    `mapstructure:"name"`
+	Help        string    `mapstructure:"help"`
+	Buckets     []float64 `mapstructure:"buckets"`
+	LabelNames  []string  `mapstructure:"labelNames"`
+	LabelValues []string  `mapstructure:"labelValues"`
+}
+
+type Config struct {
+	Enabled       bool            `mapstructure:"enable"`
+	ServerConfig  *ServerConfig   `mapstructure:"server"`
+	MetricConfigs *[]MetricConfig `mapstructure:"metrics"`
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		Enabled: defaultEnabled,
+		ServerConfig: &ServerConfig{
+			Address:   defaultAddress,
+			Namespace: defaultNamespace,
+			Subsystem: defaultSubsystem,
+		},
+		MetricConfigs: &[]MetricConfig{},
+	}
+}
+
+func GetConfig() *Config {
+	config := defaultConfig()
+	sub := viper.Sub(configPath)
+	if sub != nil {
+		cmd.BindSubViper(sub, configPath)
+		if err := sub.Unmarshal(&config); err != nil {
+			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
+				"falling back to defaults", configPath, viper.ConfigFileUsed())
+		}
+	}
+
+	return config
+}

--- a/probe/metrics.go
+++ b/probe/metrics.go
@@ -1,0 +1,23 @@
+package probe
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type collector interface {
+	prometheus.Collector
+}
+
+type Metric interface {
+	prometheus.Metric
+}
+
+type GaugeMetric interface {
+	prometheus.Gauge
+}
+
+type CounterMetric interface {
+	prometheus.Counter
+}
+
+type HistogramMetric interface {
+	prometheus.Histogram
+}

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -1,0 +1,129 @@
+package probe
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type _probe struct {
+	config  *Config
+	server  server
+	metrics map[string]Metric
+}
+
+var probe *_probe
+
+// Start creates a probe which serves metrics via HTTP server, if it is enabled by config and not already started.
+// Start is not thread-safe, caller should use due guards if necessary
+func Start() {
+	if probe != nil {
+		return
+	}
+	config := GetConfig()
+	if config.Enabled {
+		probe = &_probe{
+			config:  config,
+			server:  newServer(config.ServerConfig),
+			metrics: make(map[string]Metric),
+		}
+		probe.server.start()
+	}
+}
+
+// Stop stops the HTTP server. Stop is not thread-safe, caller should use due guards if necessary
+func Stop() {
+	if probe != nil {
+		probe.server.stop()
+		probe = nil
+	}
+}
+
+// Get gets the metric for the given metricId. Caller can use the returned metric by casting it to one of appropriate
+// metric types; probe.GaugeMetric, probe.CounterMetric, probe.HistogramMetric
+// - On success, returns (metric, true)
+// - If probe is disabled or not started returns (nil, false)
+func Get(metricId string) (Metric, bool) {
+	if Enabled() {
+		m, ok := probe.metrics[metricId]
+		return m, ok
+	}
+	return nil, false
+}
+
+// Set creates a metric with given metricConfig if probe is enabled and started. If config file contains a metric with
+// same id as metricConfig.Id, metricConfig values are overwritten by config file. Caller can use the returned metric by
+// casting it to one of appropriate metric types; probe.GaugeMetric, probe.CounterMetric, probe.HistogramMetric
+//  - On success, returns (metric, true)
+//  - If probe is disabled or not started, returns (nil, false)
+//  - If there is a metric created with same id previously, returns the previously created metric.
+func Set(metricConfig MetricConfig) (Metric, bool) {
+	var m Metric
+	if Enabled() {
+
+		// return if it is already defined
+		if m, ok := Get(metricConfig.Name); ok {
+			return m, ok
+		}
+
+		// check config and overwrite given metricConfig with config if id matches
+		for _, mc := range *probe.config.MetricConfigs {
+			if mc.Id == metricConfig.Id {
+				if mc.Name != "" {
+					metricConfig.Name = mc.Name
+				}
+				if mc.Help != "" {
+					metricConfig.Help = mc.Help
+				}
+				if mc.LabelValues != nil && mc.LabelNames != nil {
+					if len(mc.LabelValues) > 0 && len(mc.LabelNames) > 0 {
+						metricConfig.LabelNames = mc.LabelNames
+						metricConfig.LabelValues = mc.LabelValues
+					}
+				}
+				if mc.Buckets != nil {
+					metricConfig.Buckets = mc.Buckets
+				}
+			}
+		}
+
+		switch metricConfig.Type {
+		case "Gauge":
+			c := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: probe.server.config.Namespace,
+				Subsystem: probe.server.config.Subsystem,
+				Name:      metricConfig.Name,
+				Help:      metricConfig.Help,
+			}, metricConfig.LabelNames)
+			probe.server.register(c)
+			m = c.WithLabelValues(metricConfig.LabelValues...)
+			break
+		case "Counter":
+			c := prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: probe.server.config.Namespace,
+				Subsystem: probe.server.config.Subsystem,
+				Name:      metricConfig.Name,
+				Help:      metricConfig.Help,
+			}, metricConfig.LabelNames)
+			probe.server.register(c)
+			m = c.WithLabelValues(metricConfig.LabelValues...)
+			break
+		case "Histogram":
+			c := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: probe.server.config.Namespace,
+				Subsystem: probe.server.config.Subsystem,
+				Name:      metricConfig.Name,
+				Help:      metricConfig.Help,
+				Buckets:   nil,
+			}, metricConfig.LabelNames)
+			probe.server.register(c)
+			m = c.WithLabelValues(metricConfig.LabelValues...).(HistogramMetric)
+			break
+		default:
+		}
+		probe.metrics[metricConfig.Id] = m
+		return m, true
+	}
+	return nil, false
+}
+
+// Enabled returns true if probe is started
+func Enabled() bool {
+	return probe != nil
+}

--- a/probe/server.go
+++ b/probe/server.go
@@ -1,0 +1,41 @@
+package probe
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+type server struct {
+	config     *ServerConfig
+	registry   *prometheus.Registry
+	httpServer *http.Server
+	closed     chan error
+}
+
+func newServer(config *ServerConfig) server {
+	registry := prometheus.NewRegistry()
+	return server{
+		config:   config,
+		closed:   make(chan error, 1),
+		registry: registry,
+		httpServer: &http.Server{
+			Addr:    config.Address,
+			Handler: promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		},
+	}
+}
+
+func (s *server) register(collector collector) {
+	s.registry.Register(collector)
+}
+
+func (s *server) start() {
+	go func() {
+		s.closed <- s.httpServer.ListenAndServe()
+	}()
+}
+
+func (s *server) stop() error {
+	return s.httpServer.Close()
+}


### PR DESCRIPTION
providing metric library for relayers by abstracting prometheus details

sample usage:

```golang
      probe.Start()
      defer probe.Stop()

      var indexerErrors probe.CounterMetric
      if ie, ok := probe.Set(probe.MetricConfig{
		Id:          "IndexerErrors",
		Type:        "Counter",
		Name:        "indexerErrors",
		Help:        "number of indexer errors",
		LabelNames:  []string{"service"},
		LabelValues: []string{"indexer"},
	}); ok {
		indexerErrors = ie.(probe.CounterMetric)
	}

      	if indexerErrors != nil {
		indexerErrors.Inc()
	}
```

sample config:

```yaml
probe:
  enable: true
  server:
    address: "127.0.0.1:28080"
    namespace: "Aurora"
    subsystem: "Relayer2"
  metrics: # overwrite defaults
    - id: "IndexerErrors" # labels of IndexerErrors metric is overwritten with below labels
      labelNames:
        - "network" 
      labelValues:
        - "testnet"
```

metrics are served at `http://127.0.0.1:28080/metrics`
