### PR TITLE
Refactor configuration handling

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,7 +10,6 @@ const (
 )
 
 func StartCmd(f func(cmd *cobra.Command, args []string)) *cobra.Command {
-
 	startCmd := &cobra.Command{
 		Use:     "start",
 		Aliases: []string{"s"},
@@ -22,17 +21,13 @@ func StartCmd(f func(cmd *cobra.Command, args []string)) *cobra.Command {
 			f(cmd, args)
 		},
 	}
-	startCmd.PersistentFlags().StringP("config", "c", "", "Path of the configuration file (default -> config/testnet.yaml)")
+	startCmd.PersistentFlags().StringP("config", "c", defaultConfigFile, "Path of the configuration file")
 	return startCmd
 }
 
 func bindConfiguration(cmd *cobra.Command) error {
 	configFile, _ := cmd.Flags().GetString("config")
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-	} else {
-		viper.SetConfigFile(defaultConfigFile)
-	}
+	viper.SetConfigFile(configFile)
 
 	viper.WatchConfig()
 	if err := viper.ReadInConfig(); err != nil {

--- a/db/badger/blockHandler.go
+++ b/db/badger/blockHandler.go
@@ -24,12 +24,11 @@ type BlockHandler struct {
 	config *Config
 }
 
-func NewBlockHandler() (dbh.BlockHandler, error) {
-	return NewBlockHandlerWithCodec(codec.NewTinypackCodec())
+func NewBlockHandler(config *Config) (dbh.BlockHandler, error) {
+	return NewBlockHandlerWithCodec(config, codec.NewTinypackCodec())
 }
 
-func NewBlockHandlerWithCodec(codec codec.Codec) (dbh.BlockHandler, error) {
-	config := GetConfig()
+func NewBlockHandlerWithCodec(config *Config, codec codec.Codec) (dbh.BlockHandler, error) {
 	db, err := core.NewDB(config.Core, codec)
 	if err != nil {
 		return nil, err
@@ -307,7 +306,6 @@ func (h *BlockHandler) GetFilterLogs(ctx context.Context, filter *dbt.LogFilter)
 }
 
 func (h *BlockHandler) GetFilterChanges(ctx context.Context, filter any) (*[]interface{}, error) {
-
 	var err error
 	filterChanges := make([]interface{}, 0)
 	if bf, ok := filter.(*dbt.BlockFilter); ok {
@@ -408,7 +406,6 @@ func (h *BlockHandler) BlockNumberToHash(ctx context.Context, number common.BN64
 }
 
 func (h *BlockHandler) InsertBlock(block *indexer.Block) error {
-
 	writer := h.db.NewWriter()
 	defer writer.Cancel()
 

--- a/db/badger/config.go
+++ b/db/badger/config.go
@@ -1,12 +1,10 @@
 package badger
 
 import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
+	"github.com/dgraph-io/badger/v3"
+
 	"github.com/aurora-is-near/relayer2-base/db/badger/core"
 	"github.com/aurora-is-near/relayer2-base/log"
-
-	"github.com/dgraph-io/badger/v3"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -15,15 +13,13 @@ const (
 	defaultLogScanRangeThreshold = 3000
 	defaultLogMaxScanIterators   = 10000
 	defaultDataPath              = "/tmp/badger/data"
-
-	configPath = "db.badger"
 )
 
 type Config struct {
 	Core core.Config `mapstructure:"core"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	badgerOptions := badger.DefaultOptions(defaultDataPath)
 	badgerOptions.Logger = NewBadgerLogger(log.Log())
 	return &Config{
@@ -35,17 +31,4 @@ func defaultConfig() *Config {
 			BadgerConfig:       badgerOptions,
 		},
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-	return config
 }

--- a/db/badger/filterHandler.go
+++ b/db/badger/filterHandler.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"context"
 	"errors"
+
 	dbh "github.com/aurora-is-near/relayer2-base/db"
 	"github.com/aurora-is-near/relayer2-base/db/badger/core"
 	"github.com/aurora-is-near/relayer2-base/db/codec"
@@ -16,12 +17,11 @@ type FilterHandler struct {
 	config *Config
 }
 
-func NewFilterHandler() (dbh.FilterHandler, error) {
-	return NewFilterHandlerWithCodec(codec.NewTinypackCodec())
+func NewFilterHandler(config *Config) (dbh.FilterHandler, error) {
+	return NewFilterHandlerWithCodec(config, codec.NewTinypackCodec())
 }
 
-func NewFilterHandlerWithCodec(codec codec.Codec) (dbh.FilterHandler, error) {
-	config := GetConfig()
+func NewFilterHandlerWithCodec(config *Config, codec codec.Codec) (dbh.FilterHandler, error) {
 	db, err := core.NewDB(config.Core, codec)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,6 @@ func (h *FilterHandler) DeleteFilter(ctx context.Context, filterId primitives.Da
 			}
 		}
 		return errors.New("filter not found")
-
 	})
 }
 

--- a/endpoint/config.go
+++ b/endpoint/config.go
@@ -2,16 +2,12 @@ package endpoint
 
 import (
 	"fmt"
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-	"github.com/aurora-is-near/relayer2-base/types/common"
 	"math/big"
 
-	"github.com/spf13/viper"
+	"github.com/aurora-is-near/relayer2-base/types/common"
 )
 
 const (
-	configPath                           = "endpoint"
 	asyncSendRawTxsDefault               = true
 	minGasPriceDefault                   = 0
 	minGasLimitDefault                   = 21000
@@ -30,19 +26,15 @@ type EthConfig struct {
 }
 
 type Config struct {
-	ProxyUrl          string
-	ProxyEndpoints    map[string]bool `mapstructure:"proxyEndpoints"`
+	ProxyConfig       `mapstructure:"proxyEndpoints"`
 	DisabledEndpoints map[string]bool `mapstructure:"disabledEndpoints"`
 	EthConfig         EthConfig       `mapstructure:"eth"`
 	EngineConfig      EngineConfig    `mapstructure:"engine"`
 }
 
-type ethConfig struct {
-	ProtocolVersion int `mapstructure:"protocolVersion"`
-	Hashrate        int `mapstructure:"hashrate"`
-	GasEstimate     int `mapstructure:"gasEstimate"`
-	GasPrice        int `mapstructure:"gasPrice"`
-	ZeroAddress     int `mapstructure:"zeroAddress"`
+type ProxyConfig struct {
+	ProxyUrl       string          `mapstructure:"url"`
+	ProxyEndpoints map[string]bool `mapstructure:"endpoints"`
 }
 
 type EngineConfig struct {
@@ -59,106 +51,32 @@ type EngineConfig struct {
 	RetryNumberForNearTxsCall     int      `mapstructure:"retryNumberForNearTxsCall"`
 }
 
-type engineConfig struct {
-	NearNetworkID                 string `mapstructure:"nearNetworkID"`
-	NearNodeURL                   string `mapstructure:"nearNodeURL"`
-	Signer                        string `mapstructure:"signer"`
-	SignerKey                     string `mapstructure:"signerKey"`
-	AsyncSendRawTxs               bool   `mapstructure:"asyncSendRawTxs"`
-	MinGasPrice                   uint64 `mapstructure:"minGasPrice"`
-	MinGasLimit                   uint64 `mapstructure:"minGasLimit"`
-	GasForNearTxsCall             uint64 `mapstructure:"gasForNearTxsCall"`
-	DepositForNearTxsCall         uint64 `mapstructure:"depositForNearTxsCall"`
-	RetryWaitTimeMsForNearTxsCall int    `mapstructure:"retryWaitTimeMsForNearTxsCall"`
-	RetryNumberForNearTxsCall     int    `mapstructure:"retryNumberForNearTxsCall"`
-}
-
-type proxyConfig struct {
-	Url       string   `mapstructure:"url"`
-	Endpoints []string `mapstructure:"endpoints"`
-}
-
-type config struct {
-	ProxyConfig       proxyConfig  `mapstructure:"proxyEndpoints"`
-	DisabledEndpoints []string     `mapstructure:"disabledEndpoints"`
-	EthConfig         ethConfig    `mapstructure:"eth"`
-	EngineConfig      engineConfig `mapstructure:"engine"`
-}
-
-func defaultConfig() *config {
-	return &config{
-		ProxyConfig: proxyConfig{
-			Url:       "https://testnet.aurora.dev:443",
-			Endpoints: []string{},
+func DefaultConfig() *Config {
+	return &Config{
+		ProxyConfig: ProxyConfig{
+			ProxyUrl:       "https://testnet.aurora.dev:443",
+			ProxyEndpoints: map[string]bool{},
 		},
-		DisabledEndpoints: []string{},
-		EthConfig: ethConfig{
-			ProtocolVersion: 0x41,
-			Hashrate:        0,
-			GasEstimate:     0x6691b7,
-			GasPrice:        0x42c1d80,
-			ZeroAddress:     0,
+		DisabledEndpoints: map[string]bool{},
+		EthConfig: EthConfig{
+			ProtocolVersion: common.IntToUint256(0x41),
+			Hashrate:        common.IntToUint256(0),
+			GasEstimate:     common.IntToUint256(0x6691b7),
+			GasPrice:        common.IntToUint256(0x42c1d80),
+			ZeroAddress:     fmt.Sprintf("0x%040x", 0),
 		},
-		EngineConfig: engineConfig{
+		EngineConfig: EngineConfig{
 			NearNetworkID:                 "",
 			NearNodeURL:                   "",
 			Signer:                        "",
 			SignerKey:                     "",
 			AsyncSendRawTxs:               asyncSendRawTxsDefault,
-			MinGasPrice:                   minGasPriceDefault,
+			MinGasPrice:                   big.NewInt(minGasPriceDefault),
 			MinGasLimit:                   minGasLimitDefault,
 			GasForNearTxsCall:             GasForNearTxsCallDefault,
-			DepositForNearTxsCall:         DepositForNearTxsCallDefault,
+			DepositForNearTxsCall:         big.NewInt(DepositForNearTxsCallDefault),
 			RetryWaitTimeMsForNearTxsCall: retryWaitTimeMsForNearTxsCallDefault,
 			RetryNumberForNearTxsCall:     retryNumberForNearTxsCallDefault,
 		},
 	}
-}
-
-func GetConfig() *Config {
-	c := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&c); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-
-	config := &Config{
-		EthConfig: EthConfig{
-			ProtocolVersion: common.IntToUint256(c.EthConfig.ProtocolVersion),
-			Hashrate:        common.IntToUint256(c.EthConfig.Hashrate),
-			GasEstimate:     common.IntToUint256(c.EthConfig.GasEstimate),
-			GasPrice:        common.IntToUint256(c.EthConfig.GasPrice),
-			ZeroAddress:     fmt.Sprintf("0x%040x", c.EthConfig.ZeroAddress),
-		},
-		EngineConfig: EngineConfig{
-			NearNetworkID:                 c.EngineConfig.NearNetworkID,
-			NearNodeURL:                   c.EngineConfig.NearNodeURL,
-			Signer:                        c.EngineConfig.Signer,
-			SignerKey:                     c.EngineConfig.SignerKey,
-			AsyncSendRawTxs:               c.EngineConfig.AsyncSendRawTxs,
-			MinGasPrice:                   big.NewInt(0).SetUint64(c.EngineConfig.MinGasPrice),
-			MinGasLimit:                   c.EngineConfig.MinGasLimit,
-			GasForNearTxsCall:             c.EngineConfig.GasForNearTxsCall,
-			DepositForNearTxsCall:         big.NewInt(0).SetUint64(c.EngineConfig.DepositForNearTxsCall),
-			RetryWaitTimeMsForNearTxsCall: c.EngineConfig.RetryWaitTimeMsForNearTxsCall,
-			RetryNumberForNearTxsCall:     c.EngineConfig.RetryNumberForNearTxsCall,
-		},
-		DisabledEndpoints: make(map[string]bool, len(c.DisabledEndpoints)),
-		ProxyEndpoints:    make(map[string]bool, len(c.ProxyConfig.Endpoints)),
-		ProxyUrl:          c.ProxyConfig.Url,
-	}
-
-	for _, de := range c.DisabledEndpoints {
-		config.DisabledEndpoints[de] = true
-	}
-
-	for _, pe := range c.ProxyConfig.Endpoints {
-		config.ProxyEndpoints[pe] = true
-	}
-
-	return config
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -2,14 +2,14 @@ package endpoint
 
 import (
 	"encoding/json"
-	"github.com/aurora-is-near/relayer2-base/db"
-	"github.com/aurora-is-near/relayer2-base/log"
 
 	"golang.org/x/net/context"
+
+	"github.com/aurora-is-near/relayer2-base/db"
+	"github.com/aurora-is-near/relayer2-base/log"
 )
 
 func Process[T any](ctx context.Context, name string, endpoint *Endpoint, handler func(ctx context.Context) (*T, error), args ...any) (*T, error) {
-
 	var resp any
 	var err error
 	var stop bool
@@ -62,14 +62,14 @@ type Endpoint struct {
 	Processors    []Processor
 }
 
-func New(dbh db.Handler) *Endpoint {
+func New(config *Config, dbh db.Handler) *Endpoint {
 	if dbh == nil {
 		log.Log().Fatal().Msg("DB Handler should be initialized")
 	}
 	ep := Endpoint{
 		DbHandler:  dbh,
 		Logger:     log.Log(),
-		Config:     GetConfig(),
+		Config:     config,
 		Processors: []Processor{},
 	}
 
@@ -84,6 +84,6 @@ func withProcessor(e *Endpoint, p Processor) {
 	e.Processors = append(e.Processors, p)
 }
 
-func (e *Endpoint) HandleConfigChange() {
-	e.Config = GetConfig()
+func (e *Endpoint) HandleConfigChange(config *Config) {
+	e.Config = config
 }

--- a/indexer/prehistory/config.go
+++ b/indexer/prehistory/config.go
@@ -1,19 +1,10 @@
 package prehistory
 
-import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-
-	"github.com/spf13/viper"
-)
-
 const (
 	defaultIndexFromPrehistory = false
 	defaultFromBlock           = 0
 	defaultBatchSize           = 10000
 	defaultPrehistoryChainId   = 1313161554
-
-	configPath = "prehistoryIndexer"
 )
 
 type Config struct {
@@ -26,24 +17,11 @@ type Config struct {
 	PrehistoryChainId   uint64 `mapstructure:"prehistoryChainId"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		IndexFromPrehistory: defaultIndexFromPrehistory,
 		From:                defaultFromBlock,
 		BatchSize:           defaultBatchSize,
 		PrehistoryChainId:   defaultPrehistoryChainId,
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-	return config
 }

--- a/indexer/prehistory/indexer.go
+++ b/indexer/prehistory/indexer.go
@@ -3,20 +3,19 @@ package prehistory
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/aurora-is-near/relayer2-base/db"
 	"github.com/aurora-is-near/relayer2-base/log"
 	"github.com/aurora-is-near/relayer2-base/types/indexer"
 	"github.com/aurora-is-near/relayer2-base/types/primitives"
 	"github.com/aurora-is-near/relayer2-base/utils"
-
-	"fmt"
-
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -45,13 +44,12 @@ type queryResultMapping struct {
 
 // New creates the prehistory indexer, the db.Handler should not be nil and
 // configuration file prehistory part should be properly set
-func New(dbh db.Handler) (*Indexer, error) {
+func New(config *Config, dbh db.Handler) (*Indexer, error) {
 	if dbh == nil {
 		return nil, errors.New("db handler is not initialized")
 	}
 
 	logger := log.Log()
-	config := GetConfig()
 	if !config.IndexFromPrehistory {
 		return nil, nil
 	}

--- a/indexer/tar/config.go
+++ b/indexer/tar/config.go
@@ -1,15 +1,7 @@
 package tar
 
-import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-	"github.com/spf13/viper"
-)
-
 const (
 	DefaultIndexFromBackup = false
-
-	configPath = "backupIndexer"
 )
 
 type Config struct {
@@ -20,21 +12,8 @@ type Config struct {
 	To              uint64 `mapstructure:"to"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		IndexFromBackup: DefaultIndexFromBackup,
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-	return config
 }

--- a/indexer/tar/indexer.go
+++ b/indexer/tar/indexer.go
@@ -3,14 +3,16 @@ package tar
 import (
 	"bytes"
 	"fmt"
-	"github.com/aurora-is-near/relayer2-base/db"
-	"github.com/aurora-is-near/relayer2-base/db/codec"
-	"github.com/aurora-is-near/relayer2-base/types/indexer"
+
+	"github.com/aurora-is-near/stream-backup/chunks"
 	"github.com/aurora-is-near/stream-backup/messagebackup"
 	"github.com/fxamacker/cbor/v2"
+
+	"github.com/aurora-is-near/relayer2-base/db"
+	"github.com/aurora-is-near/relayer2-base/db/codec"
+	"github.com/aurora-is-near/relayer2-base/log"
+	"github.com/aurora-is-near/relayer2-base/types/indexer"
 )
-import "github.com/aurora-is-near/relayer2-base/log"
-import "github.com/aurora-is-near/stream-backup/chunks"
 
 type Indexer struct {
 	dbh    db.Handler
@@ -20,10 +22,8 @@ type Indexer struct {
 	mode   cbor.DecMode
 }
 
-func New(dbh db.Handler) (*Indexer, error) {
-
+func New(config *Config, dbh db.Handler) (*Indexer, error) {
 	logger := log.Log()
-	config := GetConfig()
 
 	if !config.IndexFromBackup {
 		return nil, nil
@@ -37,12 +37,12 @@ func New(dbh db.Handler) (*Indexer, error) {
 		reader: chunks.Chunks{
 			Dir:             config.Dir,
 			ChunkNamePrefix: config.NamePrefix,
-		}}
+		},
+	}
 	return i, nil
 }
 
 func (i *Indexer) Start() {
-
 	if !i.config.IndexFromBackup {
 		return
 	}
@@ -91,7 +91,6 @@ func (i *Indexer) Start() {
 }
 
 func (i *Indexer) Close() {
-
 }
 
 func DecodeAugmentedCBOR[T any](input []byte, mode cbor.DecMode) (*T, error) {

--- a/log/config.go
+++ b/log/config.go
@@ -1,18 +1,10 @@
 package log
 
-import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
-
-	"github.com/spf13/viper"
-)
-
 const (
 	defaultLogFilePath = "/tmp/relayer/log/relayer.log"
 	defaultLogLevel    = "info"
 	defaultLogToFile   = true
 	defaultLogToStdOut = true
-
-	configPath = "logger"
 )
 
 type Config struct {
@@ -22,21 +14,11 @@ type Config struct {
 	FilePath     string `mapstructure:"filePath"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		LogToFile:    defaultLogToFile,
 		LogToConsole: defaultLogToStdOut,
 		Level:        defaultLogLevel,
 		FilePath:     defaultLogFilePath,
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		_ = sub.Unmarshal(&config)
-	}
-	return config
 }

--- a/probe/config.go
+++ b/probe/config.go
@@ -1,18 +1,10 @@
 package probe
 
-import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-	"github.com/spf13/viper"
-)
-
 const (
 	defaultAddress   = "127.0.0.1:28080"
 	defaultNamespace = "Aurora"
 	defaultSubsystem = "Relayer2"
 	defaultEnabled   = false
-
-	configPath = "probe"
 )
 
 type ServerConfig struct {
@@ -37,7 +29,7 @@ type Config struct {
 	MetricConfigs *[]MetricConfig `mapstructure:"metrics"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		Enabled: defaultEnabled,
 		ServerConfig: &ServerConfig{
@@ -47,18 +39,4 @@ func defaultConfig() *Config {
 		},
 		MetricConfigs: &[]MetricConfig{},
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-
-	return config
 }

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -12,11 +12,10 @@ var probe *_probe
 
 // Start creates a probe which serves metrics via HTTP server, if it is enabled by config and not already started.
 // Start is not thread-safe, caller should use due guards if necessary
-func Start() {
+func Start(config *Config) {
 	if probe != nil {
 		return
 	}
-	config := GetConfig()
 	if config.Enabled {
 		probe = &_probe{
 			config:  config,

--- a/rpcnode/github-ethereum-go-ethereum/config.go
+++ b/rpcnode/github-ethereum-go-ethereum/config.go
@@ -3,12 +3,10 @@ package github_ethereum_go_ethereum
 import (
 	"time"
 
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-
 	gel "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/spf13/viper"
+
+	"github.com/aurora-is-near/relayer2-base/log"
 )
 
 const (
@@ -16,8 +14,6 @@ const (
 	DefaultHTTPPort   = 8545        // Default TCP port for the HTTP RPC server
 	DefaultWSPort     = 8546        // Default TCP port for the websocket RPC server
 	DefaultPathPrefix = ""          // Default TCP port for the websocket RPC server
-
-	configPath = "rpcNode.geth"
 )
 
 // defaultHTTPTimeouts represents the default timeout values used by the RPC server if further
@@ -33,7 +29,6 @@ var defaultHTTPTimeouts = rpc.HTTPTimeouts{
 // P2P network layer of a protocol stack. These values can be further extended by
 // all registered services.
 type Config struct {
-
 	// HTTPHost is the host interface on which to start the HTTP RPC server. If this
 	// field is empty, no HTTP API endpoint will be started.
 	HTTPHost string
@@ -109,7 +104,7 @@ type Config struct {
 // WSModules: ["net", "web3", "eth"]
 // WSPathPrefix: DefaultPathPrefix
 // WSOrigins: []
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		HTTPHost:         DefaultHost,
 		HTTPPort:         DefaultHTTPPort,
@@ -120,17 +115,4 @@ func defaultConfig() *Config {
 		HTTPTimeouts:     defaultHTTPTimeouts,
 		Logger:           NewGoEthLogger(log.Log()),
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-	return config
 }

--- a/rpcnode/github-neonxp-jsonrpc2/config.go
+++ b/rpcnode/github-neonxp-jsonrpc2/config.go
@@ -1,17 +1,8 @@
 package github_neonxp_jsonrpc2
 
-import (
-	"github.com/aurora-is-near/relayer2-base/cmd"
-	"github.com/aurora-is-near/relayer2-base/log"
-
-	"github.com/spf13/viper"
-)
-
 const (
 	defaultHttpHost = "localhost" // Default host interface for the HTTP RPC server
 	defaultHttpPort = 8545        // Default TCP port for the HTTP RPC server
-
-	configPath = "rpcNode.jsonRpc2"
 )
 
 type Config struct {
@@ -19,22 +10,9 @@ type Config struct {
 	HttpHost string `mapstructure:"httpHost"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		HttpPort: defaultHttpPort,
 		HttpHost: defaultHttpHost,
 	}
-}
-
-func GetConfig() *Config {
-	config := defaultConfig()
-	sub := viper.Sub(configPath)
-	if sub != nil {
-		cmd.BindSubViper(sub, configPath)
-		if err := sub.Unmarshal(&config); err != nil {
-			log.Log().Warn().Err(err).Msgf("failed to parse configuration [%s] from [%s], "+
-				"falling back to defaults", configPath, viper.ConfigFileUsed())
-		}
-	}
-	return config
 }

--- a/rpcnode/github-neonxp-jsonrpc2/rpcnode.go
+++ b/rpcnode/github-neonxp-jsonrpc2/rpcnode.go
@@ -3,21 +3,18 @@ package github_neonxp_jsonrpc2
 import (
 	"context"
 	"fmt"
-	"github.com/aurora-is-near/relayer2-base/log"
+
 	"go.neonxp.dev/jsonrpc2/rpc"
 	"go.neonxp.dev/jsonrpc2/transport"
+
+	"github.com/aurora-is-near/relayer2-base/log"
 )
 
 type JsonRpc2 struct {
 	rpc.RpcServer
 }
 
-func New() (*JsonRpc2, error) {
-	config := GetConfig()
-	return NewWithConf(config)
-}
-
-func NewWithConf(config *Config) (*JsonRpc2, error) {
+func New(config *Config) (*JsonRpc2, error) {
 	n := rpc.New(
 		rpc.WithLogger(NewNeonxpJsonRpc2Logger(log.Log())),
 		rpc.WithTransport(&transport.HTTP{Bind: fmt.Sprintf("%s:%d", config.HttpHost, config.HttpPort)}),

--- a/utils/mapstructure.go
+++ b/utils/mapstructure.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"math/big"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/aurora-is-near/relayer2-base/types/common"
+)
+
+func StringSliceToMapHookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.Slice || t != reflect.TypeOf(map[string]bool{}) {
+			return data, nil
+		}
+		m := make(map[string]bool)
+		for _, s := range data.([]interface{}) {
+			s, ok := s.(string)
+			if !ok {
+				return data, nil
+			}
+			m[s] = true
+		}
+		return m, nil
+	}
+}
+
+func BigIntHookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if t != reflect.TypeOf(big.Int{}) {
+			return data, nil
+		}
+		switch f.Kind() {
+		case reflect.Int:
+			b := big.NewInt(int64(data.(int)))
+			return b, nil
+		case reflect.Uint:
+			b := big.NewInt(0)
+			b = b.SetUint64(uint64(data.(uint)))
+			return b, nil
+		case reflect.String:
+			b := big.NewInt(0)
+			b, ok := b.SetString(data.(string), 0)
+			if !ok {
+				return data, nil
+			}
+			return b, nil
+		default:
+			return data, nil
+		}
+	}
+}
+
+func Uint256HookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.Int || t != reflect.TypeOf(common.Uint256{}) {
+			return data, nil
+		}
+		u256 := common.IntToUint256(data.(int))
+		return u256, nil
+	}
+}


### PR DESCRIPTION
Currently each component implicitly reads in their own configuration from viper, this behaviour is opaque to the user which won't know what configuration ends up being used. It necessitates supplying configuration through viper which complicates both normal use and testing.
This patch does the following:
1. Removes the viper dependency from relayer's components and requires/enables caller to provide the wanted configuration. 
2. Makes the `defaultConfig()` functions public for user.
3. Provides some helper `mapstructure` decode hooks to enable unmarshaling the more complicated types directly, e.g. `[]string` to `map[string]bool`, or `common.Uint256`. This is done to remove the need of a helper struct for unmarshaling.

Some responsibility with remaining global state is moved to the user such as calling `log.Initialize(config)` to configure the global logger.