### PR TITLE
Make component configurations public

### DIFF
--- a/db/badger/filterHandler.go
+++ b/db/badger/filterHandler.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"context"
 	"errors"
-	dbh "github.com/aurora-is-near/relayer2-base/db"
+
 	"github.com/aurora-is-near/relayer2-base/db/badger/core"
 	"github.com/aurora-is-near/relayer2-base/db/codec"
 	dbt "github.com/aurora-is-near/relayer2-base/types/db"
@@ -12,15 +12,15 @@ import (
 )
 
 type FilterHandler struct {
+	Config *Config
 	db     *core.DB
-	config *Config
 }
 
-func NewFilterHandler() (dbh.FilterHandler, error) {
+func NewFilterHandler() (*FilterHandler, error) {
 	return NewFilterHandlerWithCodec(codec.NewTinypackCodec())
 }
 
-func NewFilterHandlerWithCodec(codec codec.Codec) (dbh.FilterHandler, error) {
+func NewFilterHandlerWithCodec(codec codec.Codec) (*FilterHandler, error) {
 	config := GetConfig()
 	db, err := core.NewDB(config.Core, codec)
 	if err != nil {
@@ -28,7 +28,7 @@ func NewFilterHandlerWithCodec(codec codec.Codec) (dbh.FilterHandler, error) {
 	}
 	return &FilterHandler{
 		db:     db,
-		config: config,
+		Config: config,
 	}, nil
 }
 
@@ -126,7 +126,6 @@ func (h *FilterHandler) DeleteFilter(ctx context.Context, filterId primitives.Da
 			}
 		}
 		return errors.New("filter not found")
-
 	})
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,17 +1,19 @@
 package log
 
 import (
-	"github.com/aurora-is-near/relayer2-base/syncutils"
 	"io"
 	"os"
 
 	"github.com/rs/zerolog"
+
+	"github.com/aurora-is-near/relayer2-base/syncutils"
 )
 
 var globalPtr syncutils.LockablePtr[Logger]
 
 type Logger struct {
 	zerolog.Logger
+	Config *Config
 }
 
 func (l *Logger) HandleConfigChange() {
@@ -50,5 +52,8 @@ func log() *Logger {
 	if config.LogToFile {
 		writers = append(writers, NewFileWriter(config.FilePath))
 	}
-	return &Logger{zerolog.New(io.MultiWriter(writers...)).With().Timestamp().Logger()}
+	return &Logger{
+		Logger: zerolog.New(io.MultiWriter(writers...)).With().Timestamp().Logger(),
+		Config: config,
+	}
 }

--- a/rpcnode/github-ethereum-go-ethereum/rpcnode.go
+++ b/rpcnode/github-ethereum-go-ethereum/rpcnode.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"time"
 
-	"github.com/aurora-is-near/relayer2-base/broker"
-	"github.com/aurora-is-near/relayer2-base/log"
-	eventbroker "github.com/aurora-is-near/relayer2-base/rpcnode/github-ethereum-go-ethereum/events"
-	"golang.org/x/net/context"
-
 	gel "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/jinzhu/copier"
+	"golang.org/x/net/context"
+
+	"github.com/aurora-is-near/relayer2-base/broker"
+	"github.com/aurora-is-near/relayer2-base/log"
+	eventbroker "github.com/aurora-is-near/relayer2-base/rpcnode/github-ethereum-go-ethereum/events"
 )
 
 const (
@@ -25,6 +25,7 @@ const (
 type GoEthereum struct {
 	node.Node
 	Broker broker.Broker
+	Config *Config
 }
 
 type connection struct {
@@ -70,6 +71,7 @@ func NewWithConf(conf *Config) (*GoEthereum, error) {
 	return &GoEthereum{
 		Node:   *n,
 		Broker: eb,
+		Config: conf,
 	}, nil
 }
 


### PR DESCRIPTION
As an alternative method to https://github.com/aurora-is-near/relayer2-base/pull/108 for the goal of enabling configuration logging, make the config of each component public.
Note that behaviour of tar indexer and prehistory indexer changes, an indexer is returned from `New()` instead of `nil` when indexing is not needed and `Start()` becomes a no-op.