### PR TITLE
Fix big.Int unmarshal issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/fxamacker/cbor/v2 v2.4.0
+	github.com/holiman/uint256 v1.2.0
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/near/borsh-go v0.3.1
@@ -22,6 +23,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
 	go.neonxp.dev/jsonrpc2 v1.2.0
+	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a
 	golang.org/x/net v0.8.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
@@ -60,7 +62,6 @@ require (
 	github.com/tklauser/numcpus v0.5.0 // indirect
 	github.com/urfave/cli/v2 v2.19.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuW
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=

--- a/types/indexer/indexer.go
+++ b/types/indexer/indexer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aurora-is-near/relayer2-base/types/primitives"
 	"github.com/aurora-is-near/relayer2-base/types/utils"
 	"github.com/btcsuite/btcutil/base58"
-	"math/big"
 	"strconv"
 	"strings"
 )
@@ -142,12 +141,14 @@ func (t *Topic) UnmarshalCBOR(b []byte) error {
 }
 
 func (s *Size) UnmarshalJSON(b []byte) error {
-	var bi big.Int
-	err := json.Unmarshal(b, &bi)
+	var in string
+	err := json.Unmarshal(b, &in)
+
+	ui64, err := utils.HexStringToUint64(in)
 	if err != nil {
 		return err
 	}
-	*s = Size(bi.Uint64())
+	*s = Size(ui64)
 	return nil
 }
 

--- a/types/primitives/quantity.go
+++ b/types/primitives/quantity.go
@@ -3,9 +3,10 @@ package primitives
 import (
 	"encoding/binary"
 	"encoding/json"
-	tp "github.com/aurora-is-near/relayer2-base/tinypack"
 	"math/big"
 	"reflect"
+
+	tp "github.com/aurora-is-near/relayer2-base/tinypack"
 
 	"github.com/fxamacker/cbor/v2"
 )
@@ -54,23 +55,21 @@ func (q Quantity) MarshalJSON() ([]byte, error) {
 }
 
 func (q *Quantity) UnmarshalJSON(b []byte) error {
-
 	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
 		return &json.UnmarshalTypeError{Value: "non-string", Type: reflect.ValueOf(Quantity{}).Type()}
 	}
 
-	var bi big.Int
-	err := json.Unmarshal(b, &bi)
+	var in string
+	err := json.Unmarshal(b, &in)
 	if err != nil {
 		return err
 	}
 
-	*q = QuantityFromHex(bi.String())
+	*q = QuantityFromHex(in)
 	return nil
 }
 
 func (q *Quantity) UnmarshalCBOR(b []byte) error {
-
 	var in string
 	err := cbor.Unmarshal(b, &in)
 	if err != nil {


### PR DESCRIPTION
 Please check issue #112 for details. 

This PR implements the following fixes. 
 * Port the big.Int unmarshaller from go-ethereum project to fix the primitives.Quantity issue
 * update `Size` type with `HexUint` type