### PR TITLE
133: Return version info in response header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aurora-is-near/stream-backup v0.0.0-20221212013533-1e06e263c3f7
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/buger/jsonparser v1.1.1
+	github.com/carlmjohnson/versioninfo v0.22.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/fasthttp/websocket v1.5.2
@@ -80,7 +81,7 @@ require (
 	github.com/valyala/fasthttp v1.47.0
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/atomic v1.10.0
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/carlmjohnson/versioninfo v0.22.4 h1:AucUHDSKmk6j7Yx3dECGUxaowGHOAN0Zx5/EBtsXn4Y=
+github.com/carlmjohnson/versioninfo v0.22.4/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -178,6 +178,8 @@ func (h *HttpServer) handleWebSocketOutput(wsCtx *WebSocketContext) {
 
 // fastHTTPHandler is the handler to serve HTTP requests
 func (h *HttpServer) fastHTTPHandler(ctx *fasthttp.RequestCtx, r *http.Request) {
+	ctx.Response.Header.SetServer("Relayer " + *utils.Constants.RelayerVersion())
+
 	if code, err := validateRequest(r); err != nil {
 		ctx.Error(err.Error(), code)
 		return


### PR DESCRIPTION
Server header value added to the response header (like `Server: Relayer v2.1.0`)
The version info first checked from build info file. If build info file doesn't exist or the version tag is empty, then the latest commit has used.