### PR TITLE
135: fix subscription issues

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -154,7 +154,6 @@ func (h *HttpServer) fastWsHandler(ctx *fasthttp.RequestCtx) {
 
 		wsCtx.closed.Store(true)
 		h.resolver.CloseWsConn(wsCtx)
-		close(wsCtx.output)
 		wsCtx.outputWg.Wait()
 	})
 	if err != nil {


### PR DESCRIPTION
This PR fixes the following issues

- write on closed channel error -> Best practice is not to delete the channel and leave it to GC if multiple writers exists.
-  memory leak due to improper handling of notifiers data structure -> Notifiers slice removed to prevent concurrency problems. Instead per connection context objects used and tested with go-profiler
- some minor enhancements