### PR TITLE
145: Support rpc path prefix options

### DIFF
--- a/rpc/node/config.go
+++ b/rpc/node/config.go
@@ -21,6 +21,7 @@ var (
 	defaultHttpTimeout        time.Duration = 300
 	defaultWsHandshakeTimeout time.Duration = 10
 	defaultMaxBatchRequests   uint          = 1000
+	DefaultPathPrefix         string        = "*"
 )
 
 type Config struct {
@@ -29,8 +30,10 @@ type Config struct {
 	HttpCors           []string      `mapstructure:"httpCors"`
 	HttpCompress       bool          `mapstructure:"httpCompress"`
 	HttpTimeout        time.Duration `mapstructure:"httpTimeout"`
+	HttpPathPrefix     string        `mapstructure:"httpPathPrefix"`
 	WsPort             int16         `mapstructure:"wsPort"`
 	WsHost             string        `mapstructure:"wsHost"`
+	WsPathPrefix       string        `mapstructure:"wsPathPrefix"`
 	WsHandshakeTimeout time.Duration `mapstructure:"wsHandshakeTimeout"`
 	MaxBatchRequests   uint          `mapstructure:"maxBatchRequests"`
 }
@@ -57,9 +60,11 @@ func defaultConfig() *Config {
 	return &Config{
 		HttpPort:           defaultHttpPort,
 		HttpHost:           defaultHttpHost,
+		HttpPathPrefix:     DefaultPathPrefix,
 		HttpCors:           []string{},
 		HttpCompress:       defaultHttpCompress,
 		HttpTimeout:        defaultHttpTimeout,
+		WsPathPrefix:       DefaultPathPrefix,
 		WsHandshakeTimeout: defaultWsHandshakeTimeout,
 		MaxBatchRequests:   defaultMaxBatchRequests,
 	}


### PR DESCRIPTION
The following go-ethereum config params are added
1.  httpPathPrefix
2. wsPathPrefix

details 
- default value ->  "*" which allows all paths
- If no prefix specified ("") or provided as "/", then request URL must be on root. Please note that no prefix scenario (case "") keeped not to break go-ethereum compatibility. 
- "/xxx" -> all paths with that prefix ("/xxxyz") or child paths are allowed ("/xxx/yyy/zzz")
- HTTP 404 status code returned for incorrect path cases (suggested as a security best practice)
- invalid configurations cause fatal error during server initialization  
